### PR TITLE
Move to api v3 and python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: python
 python:
-  - "2.6"
-  - "2.7"
+  - "3.4"
+  - "3.5"
+  - "3.6-dev"
+  - "3.7-dev"
 install:
   - pip install -r requirements.txt
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ python:
   - "2.6"
   - "2.7"
 install:
-  - pip install -r requirements.txt --use-mirrors
+  - pip install -r requirements.txt
 before_script:
-  - pip install -r test_requirements.txt --use-mirrors
+  - pip install -r test_requirements.txt
 script:
   - py.test --doctest-modules --pep8 fanart -v --cov fanart --cov-report term-missing
 after_success:

--- a/README.rst
+++ b/README.rst
@@ -1,20 +1,20 @@
-=================================
-Python interface to fanart.tv API
-=================================
+=======================================
+Python3 interface to fanart.tv API (v3)
+=======================================
 
-.. image:: https://api.travis-ci.org/z4r/python-fanart.png?branch=master
-   :target: http://travis-ci.org/z4r/python-fanart
+.. image:: https://api.travis-ci.org/opacam/python3-fanart.png?branch=master
+   :target: http://travis-ci.org/opacam/python3-fanart
 
-.. image:: https://coveralls.io/repos/z4r/python-fanart/badge.png?branch=master
-    :target: https://coveralls.io/r/z4r/python-fanart
+.. image:: https://coveralls.io/repos/opacam/python3-fanart/badge.png?branch=master
+    :target: https://coveralls.io/r/opacam/python3-fanart
     
-.. image:: https://pypip.in/v/python-fanart/badge.png
-   :target: https://crate.io/packages/python-fanart/
+.. image:: https://pypip.in/v/python3-fanart/badge.png
+   :target: https://pypi.python.org/pypi/python3-fanart
 
-.. image:: https://pypip.in/d/python-fanart/badge.png
-   :target: https://crate.io/packages/python-fanart/
+.. image:: https://pypip.in/d/python3-fanart/badge.png
+   :target: https://pypi.python.org/pypi/python3-fanart
 
-This package provides a module to interface with the `fanart.tv`_ API.
+This package provides a module to interface with the `fanart.tv`_ API (v3).
 
 .. contents::
     :local:
@@ -25,7 +25,7 @@ Installation
 ============
 Using pip::
 
-    $ pip install git+https://github.com/z4r/python-fanart
+    $ pip install git+https://github.com/opacam/python3-fanart
 
 .. _summary:
 

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,12 @@ Python3 interface to fanart.tv API (v3)
 .. image:: https://pypip.in/d/python3-fanart/badge.png
    :target: https://pypi.python.org/pypi/python3-fanart
 
-This package provides a module to interface with the `fanart.tv`_ API (v3).
+This package provides a module to interface with the `fanart.tv`_. It's a fork
+of the project named `python-fanart`_ but updated to work with
+`fanart.tv api v3`. It also limits the python version to 3.4+, because the end
+of life of python2 it's near (2020). To use this package you need your own
+**api key**. You can request your api key in here: `fanart.tv api key`_
+
 
 .. contents::
     :local:
@@ -47,7 +52,7 @@ Low Level
         sort=fanart.SORT.POPULAR,
         limit=fanart.LIMIT.ALL,
     )
-    print request.response()
+    print(request.response())
 
 
 Music
@@ -62,11 +67,11 @@ Music
     from fanart.music import Artist
 
     artist = Artist.get(id='24e1b53c-3085-4581-8472-0b0088d2508c')
-    print artist.name
-    print artist.mbid
+    print(artist.name)
+    print(artist.mbid)
     for album in artist.albums:
         for cover in album.covers:
-            print 'Saving: %s' % cover
+            print('Saving: %s' % cover)
             _, ext = os.path.splitext(cover.url)
             filepath = os.path.join(path, '%d%s' % (cover.id, ext))
             with open(filepath, 'wb') as fp:
@@ -110,5 +115,9 @@ file in the top distribution directory for the full license text.
 References
 ==========
 * `fanart.tv`_
+* `python-fanart`_
+* `fanart.tv api key`_
 
 .. _fanart.tv: http://fanart.tv/
+.. _python-fanart: https://github.com/z4r/python-fanart
+.. _fanart.tv api key: https://fanart.tv/get-an-api-key/

--- a/fanart/__init__.py
+++ b/fanart/__init__.py
@@ -39,7 +39,7 @@ __doc__ = """
 
 
 def values(obj):
-    return [v for k, v in obj.__dict__.iteritems() if not k.startswith('_')]
+    return [v for k, v in obj.__dict__.items() if not k.startswith('_')]
 
 BASEURL = 'http://api.fanart.tv/webservice'
 

--- a/fanart/__init__.py
+++ b/fanart/__init__.py
@@ -52,9 +52,9 @@ class FORMAT(object):
 
 
 class WS(object):
-    MUSIC = 'artist'
-    MOVIE = 'movie'
-    TV = 'series'
+    MUSIC = 'music'
+    MOVIE = 'movies'
+    TV = 'tv'
 
 
 class TYPE(object):

--- a/fanart/__init__.py
+++ b/fanart/__init__.py
@@ -103,6 +103,7 @@ class LIMIT(object):
     ONE = 1
     ALL = 2
 
+
 FORMAT_LIST = values(FORMAT)
 WS_LIST = values(WS)
 TYPE_LIST = values(TYPE.MUSIC) + values(TYPE.TV) + values(TYPE.MOVIE) + [TYPE.ALL]

--- a/fanart/__init__.py
+++ b/fanart/__init__.py
@@ -5,7 +5,10 @@ __classifiers__ = [
     'Intended Audience :: Developers',
     'License :: OSI Approved :: Apache Software License',
     'Operating System :: OS Independent',
-    'Programming Language :: Python',
+    'Programming Language :: Python :: 3.4',
+    'Programming Language :: Python :: 3.5',
+    'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
     'Topic :: Internet :: WWW/HTTP',
     'Topic :: Software Development :: Libraries',
 ]

--- a/fanart/__init__.py
+++ b/fanart/__init__.py
@@ -1,4 +1,5 @@
 __author__ = 'Andrea De Marco <24erre@gmail.com>'
+__maintainer__ = 'Pol Canelles <canellestudi@gmail.com>'
 __version__ = '1.4.0'
 __classifiers__ = [
     'Development Status :: 5 - Production/Stable',
@@ -32,7 +33,7 @@ __license__ = """
 __docformat__ = 'restructuredtext en'
 
 __doc__ = """
-:abstract: Python interface to fanart.tv API
+:abstract: Python interface to fanart.tv API (v3)
 :version: %s
 :author: %s
 :contact: http://z4r.github.com/

--- a/fanart/__init__.py
+++ b/fanart/__init__.py
@@ -66,6 +66,8 @@ class TYPE(object):
         CHARACTER = 'characterart'
         THUMB = 'tvthumb'
         SEASONTHUMB = 'seasonthumb'
+        SEASONBANNER = 'seasonbanner'
+        SEASONPOSTER = 'seasonposter'
         BACKGROUND = 'showbackground'
         HDLOGO = 'hdtvlogo'
         HDART = 'hdclearart'

--- a/fanart/__init__.py
+++ b/fanart/__init__.py
@@ -41,7 +41,8 @@ __doc__ = """
 def values(obj):
     return [v for k, v in obj.__dict__.items() if not k.startswith('_')]
 
-BASEURL = 'http://api.fanart.tv/webservice'
+
+BASEURL = 'http://webservice.fanart.tv/v3'
 
 
 class FORMAT(object):

--- a/fanart/core.py
+++ b/fanart/core.py
@@ -5,6 +5,11 @@ from fanart.errors import RequestFanartError, ResponseFanartError
 
 class Request(object):
     def __init__(self, apikey, id, ws, type=None, sort=None, limit=None):
+        '''
+        .. warning:: Since the migration to fanart.tv's api v3, we cannot use
+            the kwargs `type/sort/limit` as we did before, so for now this
+            kwargs will be ignored.
+        '''
         self._apikey = apikey
         self._id = id
         self._ws = ws
@@ -19,19 +24,17 @@ class Request(object):
             attribute = getattr(self, '_' + attribute_name)
             choices = getattr(fanart, attribute_name.upper() + '_LIST')
             if attribute not in choices:
-                raise RequestFanartError('Not allowed {0}: {1} [{2}]'.format(attribute_name, attribute, ', '.join(choices)))
+                raise RequestFanartError(
+                    'Not allowed {}: {} [{}]'.format(
+                        attribute_name, attribute, ', '.join(choices)))
 
     def __str__(self):
-        return '/'.join(map(str, [
-            fanart.BASEURL,
-            self._ws,
-            self._apikey,
-            self._id,
-            fanart.FORMAT.JSON,
-            self._type,
-            self._sort,
-            self._limit,
-        ]))
+        return '{base_url}/{ws}/{id}?api_key={apikey}'.format(
+            base_url=fanart.BASEURL,
+            ws=self._ws,
+            id=self._id,
+            apikey=self._apikey,
+        )
 
     def response(self):
         try:
@@ -39,6 +42,8 @@ class Request(object):
             rjson = response.json()
             if not isinstance(rjson, dict):
                 raise Exception(response.text)
+            if 'error message' in rjson:
+                raise Exception(rjson['status'], rjson['error message'])
             return rjson
         except Exception as e:
             raise ResponseFanartError(str(e))

--- a/fanart/immutable.py
+++ b/fanart/immutable.py
@@ -26,7 +26,7 @@ class Immutable(object):
         )
 
     def __iter__(self):
-        l = self.__dict__.keys()
+        l = list(self.__dict__.keys())
         l.sort()
         for k in l:
             if not k.startswith('_'):

--- a/fanart/items.py
+++ b/fanart/items.py
@@ -17,7 +17,7 @@ class LeafItem(Immutable):
 
     @classmethod
     def from_dict(cls, resource):
-        return cls(**dict([(str(k), v) for k, v in resource.iteritems()]))
+        return cls(**dict([(str(k), v) for k, v in resource.items()]))
 
     @classmethod
     def extract(cls, resource):
@@ -53,7 +53,9 @@ class ResourceItem(Immutable):
     def json(self, **kw):
         return json.dumps(
             self,
-            default=lambda o: dict([(k, v) for k, v in o.__dict__.items() if not k.startswith('_')]),
+            default=lambda o: dict(
+                [(k, v) for k, v in o.__dict__.items()
+                 if not k.startswith('_')]),
             **kw
         )
 
@@ -65,4 +67,4 @@ class CollectableItem(Immutable):
 
     @classmethod
     def collection_from_dict(cls, map):
-        return [cls.from_dict(k, v) for k, v in map.iteritems()]
+        return [cls.from_dict(k, v) for k, v in map.items()]

--- a/fanart/movie.py
+++ b/fanart/movie.py
@@ -85,10 +85,10 @@ class Movie(ResourceItem):
 
     @classmethod
     def from_dict(cls, resource):
-        assert len(resource) == 1, 'Bad Format Map'
-        name, resource = list(resource.items())[0]
+        minimal_keys = {'name', 'imdb_id', 'tmdb_id'}
+        assert all(k in resource for k in minimal_keys), 'Bad Format Map'
         return cls(
-            name=name,
+            name=resource['name'],
             imdbid=resource['imdb_id'],
             tmdbid=resource['tmdb_id'],
             arts=ArtItem.extract(resource),

--- a/fanart/movie.py
+++ b/fanart/movie.py
@@ -68,8 +68,8 @@ class Movie(ResourceItem):
     WS = fanart.WS.MOVIE
 
     @Immutable.mutablemethod
-    def __init__(self, name, imdbid, tmdbid, arts, logos, discs, posters, backgrounds, hdlogos, hdarts,
-                 banners, thumbs):
+    def __init__(self, name, imdbid, tmdbid, arts, logos, discs, posters,
+                 backgrounds, hdlogos, hdarts, banners, thumbs):
         self.name = name
         self.imdbid = imdbid
         self.tmdbid = tmdbid

--- a/fanart/movie.py
+++ b/fanart/movie.py
@@ -86,7 +86,7 @@ class Movie(ResourceItem):
     @classmethod
     def from_dict(cls, resource):
         assert len(resource) == 1, 'Bad Format Map'
-        name, resource = resource.items()[0]
+        name, resource = list(resource.items())[0]
         return cls(
             name=name,
             imdbid=resource['imdb_id'],

--- a/fanart/music.py
+++ b/fanart/music.py
@@ -51,10 +51,10 @@ class Artist(ResourceItem):
 
     @classmethod
     def from_dict(cls, resource):
-        assert len(resource) == 1, 'Bad Format Map'
-        name, resource = list(resource.items())[0]
+        minimal_keys = {'name', 'mbid_id'}
+        assert all(k in resource for k in minimal_keys), 'Bad Format Map'
         return cls(
-            name=name,
+            name=resource['name'],
             mbid=resource['mbid_id'],
             albums=Album.collection_from_dict(resource.get('albums', {})),
             backgrounds=BackgroundItem.extract(resource),

--- a/fanart/music.py
+++ b/fanart/music.py
@@ -52,7 +52,7 @@ class Artist(ResourceItem):
     @classmethod
     def from_dict(cls, resource):
         assert len(resource) == 1, 'Bad Format Map'
-        name, resource = resource.items()[0]
+        name, resource = list(resource.items())[0]
         return cls(
             name=name,
             mbid=resource['mbid_id'],

--- a/fanart/tests/json/wilfred.json
+++ b/fanart/tests/json/wilfred.json
@@ -1,196 +1,327 @@
 {
-    "logos": [
-        {
-            "lang": "en",
-            "url": "http://assets.fanart.tv/fanart/tv/239761/clearlogo/wilfred-us-4e04b6495dfd3.png",
-            "likes": 2,
-            "id": 11977
-        },
-        {
-            "lang": "en",
-            "url": "http://assets.fanart.tv/fanart/tv/239761/clearlogo/wilfred-us-517ac36e39f67.png",
-            "likes": 1,
-            "id": 28249
-        },
-        {
-            "lang": "en",
-            "url": "http://assets.fanart.tv/fanart/tv/239761/clearlogo/wilfred-us-51f557082cfde.png",
-            "likes": 0,
-            "id": 31817
-        }
-    ],
-    "arts": [
-        {
-            "lang": "en",
-            "url": "http://assets.fanart.tv/fanart/tv/239761/clearart/wilfred-us-4e05f10e87711.png",
-            "likes": 2,
-            "id": 11987
-        },
-        {
-            "lang": "en",
-            "url": "http://assets.fanart.tv/fanart/tv/239761/clearart/wilfred-us-4e2f151d5ed62.png",
-            "likes": 1,
-            "id": 12470
-        }
-    ],
     "name": "Wilfred (US)",
-    "hdarts": [
-        {
-            "lang": "en",
-            "url": "http://assets.fanart.tv/fanart/tv/239761/hdclearart/wilfred-us-505f94ed0ba13.png",
-            "likes": 1,
-            "id": 21112
-        },
-        {
-            "lang": "he",
-            "url": "http://assets.fanart.tv/fanart/tv/239761/hdclearart/wilfred-us-52403264aa3ec.png",
-            "likes": 1,
-            "id": 33751
-        }
-    ],
+    "tvdbid": "239761",
     "backgrounds": [
         {
-            "lang": "en",
-            "url": "http://assets.fanart.tv/fanart/tv/239761/showbackground/wilfred-us-5034dbd49115e.jpg",
             "id": 19965,
-            "season": 0,
-            "likes": 0
-        },
-        {
-            "lang": "en",
-            "url": "http://assets.fanart.tv/fanart/tv/239761/showbackground/wilfred-us-50b0c92db6973.jpg",
-            "id": 23166,
-            "season": 0,
-            "likes": 0
-        },
-        {
-            "lang": "en",
-            "url": "http://assets.fanart.tv/fanart/tv/239761/showbackground/wilfred-us-50b0c92dbb46b.jpg",
-            "id": 23167,
-            "season": 0,
-            "likes": 0
-        },
-        {
-            "lang": "en",
-            "url": "http://assets.fanart.tv/fanart/tv/239761/showbackground/wilfred-us-50b0c92dbb9d1.jpg",
-            "id": 23168,
-            "season": 0,
-            "likes": 0
-        }
-    ],
-    "thumbs": [
-        {
-            "lang": "en",
-            "url": "http://assets.fanart.tv/fanart/tv/239761/tvthumb/wilfred-us-501cf526174fe.jpg",
-            "likes": 1,
-            "id": 19596
-        },
-        {
-            "lang": "en",
-            "url": "http://assets.fanart.tv/fanart/tv/239761/tvthumb/wilfred-us-51bfb4a105904.jpg",
+            "url": "https://assets.fanart.tv/fanart/tv/239761/showbackground/wilfred-us-5034dbd49115e.jpg",
             "likes": 0,
-            "id": 30060
+            "lang": "",
+            "season": 0
+        },
+        {
+            "id": 23166,
+            "url": "https://assets.fanart.tv/fanart/tv/239761/showbackground/wilfred-us-50b0c92db6973.jpg",
+            "likes": 0,
+            "lang": "",
+            "season": 0
+        },
+        {
+            "id": 23167,
+            "url": "https://assets.fanart.tv/fanart/tv/239761/showbackground/wilfred-us-50b0c92dbb46b.jpg",
+            "likes": 0,
+            "lang": "",
+            "season": 0
+        },
+        {
+            "id": 23168,
+            "url": "https://assets.fanart.tv/fanart/tv/239761/showbackground/wilfred-us-50b0c92dbb9d1.jpg",
+            "likes": 0,
+            "lang": "",
+            "season": 0
+        },
+        {
+            "id": 36386,
+            "url": "https://assets.fanart.tv/fanart/tv/239761/showbackground/wilfred-us-52d53d75d4782.jpg",
+            "likes": 0,
+            "lang": "",
+            "season": 0
         }
     ],
     "characters": [],
-    "posters": [
+    "arts": [
         {
-            "lang": "he",
-            "url": "http://assets.fanart.tv/fanart/tv/239761/tvposter/wilfred-us-525d893230d7c.jpg",
+            "id": 11987,
+            "url": "https://assets.fanart.tv/fanart/tv/239761/clearart/wilfred-us-4e05f10e87711.png",
+            "likes": 2,
+            "lang": "en"
+        },
+        {
+            "id": 12470,
+            "url": "https://assets.fanart.tv/fanart/tv/239761/clearart/wilfred-us-4e2f151d5ed62.png",
             "likes": 1,
-            "id": 34584
+            "lang": "en"
+        }
+    ],
+    "logos": [
+        {
+            "id": 11977,
+            "url": "https://assets.fanart.tv/fanart/tv/239761/clearlogo/wilfred-us-4e04b6495dfd3.png",
+            "likes": 2,
+            "lang": "en"
+        },
+        {
+            "id": 28249,
+            "url": "https://assets.fanart.tv/fanart/tv/239761/clearlogo/wilfred-us-517ac36e39f67.png",
+            "likes": 1,
+            "lang": "en"
+        },
+        {
+            "id": 31817,
+            "url": "https://assets.fanart.tv/fanart/tv/239761/clearlogo/wilfred-us-51f557082cfde.png",
+            "likes": 0,
+            "lang": "en"
         }
     ],
     "seasons": [
         {
-            "lang": "he",
-            "url": "http://assets.fanart.tv/fanart/tv/239761/seasonthumb/wilfred-us-52403782bab55.jpg",
             "id": 33752,
-            "season": 1,
-            "likes": 1
+            "url": "https://assets.fanart.tv/fanart/tv/239761/seasonthumb/wilfred-us-52403782bab55.jpg",
+            "likes": 1,
+            "lang": "he",
+            "season": 1
         },
         {
-            "lang": "he",
-            "url": "http://assets.fanart.tv/fanart/tv/239761/seasonthumb/wilfred-us-5240379335232.jpg",
             "id": 33753,
-            "season": 2,
-            "likes": 1
-        },
-        {
+            "url": "https://assets.fanart.tv/fanart/tv/239761/seasonthumb/wilfred-us-5240379335232.jpg",
+            "likes": 1,
             "lang": "he",
-            "url": "http://assets.fanart.tv/fanart/tv/239761/seasonthumb/wilfred-us-524037bc83c7d.jpg",
+            "season": 2
+        },
+        {
             "id": 33754,
-            "season": 3,
-            "likes": 1
+            "url": "https://assets.fanart.tv/fanart/tv/239761/seasonthumb/wilfred-us-524037bc83c7d.jpg",
+            "likes": 1,
+            "lang": "he",
+            "season": 3
         },
         {
-            "lang": "en",
-            "url": "http://assets.fanart.tv/fanart/tv/239761/seasonthumb/wilfred-us-501bb0a8e60f9.jpg",
             "id": 19586,
-            "season": 1,
-            "likes": 0
+            "url": "https://assets.fanart.tv/fanart/tv/239761/seasonthumb/wilfred-us-501bb0a8e60f9.jpg",
+            "likes": 0,
+            "lang": "en",
+            "season": 1
         },
         {
-            "lang": "en",
-            "url": "http://assets.fanart.tv/fanart/tv/239761/seasonthumb/wilfred-us-501bb0b4bf229.jpg",
             "id": 19587,
-            "season": 2,
-            "likes": 0
+            "url": "https://assets.fanart.tv/fanart/tv/239761/seasonthumb/wilfred-us-501bb0b4bf229.jpg",
+            "likes": 0,
+            "lang": "en",
+            "season": 2
         },
         {
-            "lang": "en",
-            "url": "http://assets.fanart.tv/fanart/tv/239761/seasonthumb/wilfred-us-501bb144e6a46.jpg",
             "id": 19588,
-            "season": 0,
-            "likes": 0
+            "url": "https://assets.fanart.tv/fanart/tv/239761/seasonthumb/wilfred-us-501bb144e6a46.jpg",
+            "likes": 0,
+            "lang": "en",
+            "season": 0
         },
         {
-            "lang": "en",
-            "url": "http://assets.fanart.tv/fanart/tv/239761/seasonthumb/wilfred-us-51c953105ef77.jpg",
             "id": 30309,
-            "season": 3,
-            "likes": 0
+            "url": "https://assets.fanart.tv/fanart/tv/239761/seasonthumb/wilfred-us-51c953105ef77.jpg",
+            "likes": 0,
+            "lang": "en",
+            "season": 3
         }
     ],
-    "banners": [
+    "thumbs": [
         {
-            "lang": "he",
-            "url": "http://assets.fanart.tv/fanart/tv/239761/tvbanner/wilfred-us-52403a7185070.jpg",
+            "id": 19596,
+            "url": "https://assets.fanart.tv/fanart/tv/239761/tvthumb/wilfred-us-501cf526174fe.jpg",
             "likes": 1,
-            "id": 33755
+            "lang": "en"
         },
         {
-            "lang": "en",
-            "url": "http://assets.fanart.tv/fanart/tv/239761/tvbanner/wilfred-us-5265193db51f7.jpg",
-            "likes": 0,
-            "id": 34716
+            "id": 30060,
+            "url": "https://assets.fanart.tv/fanart/tv/239761/tvthumb/wilfred-us-51bfb4a105904.jpg",
+            "likes": 1,
+            "lang": "en"
         }
     ],
     "hdlogos": [
         {
-            "lang": "en",
-            "url": "http://assets.fanart.tv/fanart/tv/239761/hdtvlogo/wilfred-us-505f373be58e6.png",
-            "likes": 1,
-            "id": 21101
+            "id": 21101,
+            "url": "https://assets.fanart.tv/fanart/tv/239761/hdtvlogo/wilfred-us-505f373be58e6.png",
+            "likes": 2,
+            "lang": "en"
         },
         {
-            "lang": "en",
-            "url": "http://assets.fanart.tv/fanart/tv/239761/hdtvlogo/wilfred-us-517ac360def17.png",
-            "likes": 1,
-            "id": 28248
+            "id": 28248,
+            "url": "https://assets.fanart.tv/fanart/tv/239761/hdtvlogo/wilfred-us-517ac360def17.png",
+            "likes": 2,
+            "lang": "en"
         },
         {
-            "lang": "he",
-            "url": "http://assets.fanart.tv/fanart/tv/239761/hdtvlogo/wilfred-us-52402df7ed945.png",
+            "id": 33750,
+            "url": "https://assets.fanart.tv/fanart/tv/239761/hdtvlogo/wilfred-us-52402df7ed945.png",
             "likes": 1,
-            "id": 33750
+            "lang": "he"
         },
         {
-            "lang": "en",
-            "url": "http://assets.fanart.tv/fanart/tv/239761/hdtvlogo/wilfred-us-51f556fb4abd3.png",
+            "id": 42207,
+            "url": "https://assets.fanart.tv/fanart/tv/239761/hdtvlogo/wilfred-us-53d12425b2d8c.png",
+            "likes": 1,
+            "lang": "ru"
+        },
+        {
+            "id": 31816,
+            "url": "https://assets.fanart.tv/fanart/tv/239761/hdtvlogo/wilfred-us-51f556fb4abd3.png",
             "likes": 0,
-            "id": 31816
+            "lang": "en"
         }
     ],
-    "tvdbid": "239761"
+    "hdarts": [
+        {
+            "id": 21112,
+            "url": "https://assets.fanart.tv/fanart/tv/239761/hdclearart/wilfred-us-505f94ed0ba13.png",
+            "likes": 1,
+            "lang": "en"
+        },
+        {
+            "id": 33751,
+            "url": "https://assets.fanart.tv/fanart/tv/239761/hdclearart/wilfred-us-52403264aa3ec.png",
+            "likes": 1,
+            "lang": "he"
+        }
+    ],
+    "posters": [
+        {
+            "id": 34584,
+            "url": "https://assets.fanart.tv/fanart/tv/239761/tvposter/wilfred-us-525d893230d7c.jpg",
+            "likes": 1,
+            "lang": "he"
+        }
+    ],
+    "banners": [
+        {
+            "id": 33755,
+            "url": "https://assets.fanart.tv/fanart/tv/239761/tvbanner/wilfred-us-52403a7185070.jpg",
+            "likes": 1,
+            "lang": "he"
+        },
+        {
+            "id": 57138,
+            "url": "https://assets.fanart.tv/fanart/tv/239761/tvbanner/wilfred-us-5607140bac1c6.jpg",
+            "likes": 1,
+            "lang": "en"
+        },
+        {
+            "id": 34716,
+            "url": "https://assets.fanart.tv/fanart/tv/239761/tvbanner/wilfred-us-5265193db51f7.jpg",
+            "likes": 0,
+            "lang": "en"
+        },
+        {
+            "id": 36389,
+            "url": "https://assets.fanart.tv/fanart/tv/239761/tvbanner/wilfred-us-52d578d57cb24.jpg",
+            "likes": 0,
+            "lang": "en"
+        },
+        {
+            "id": 36390,
+            "url": "https://assets.fanart.tv/fanart/tv/239761/tvbanner/wilfred-us-52d578de27a66.jpg",
+            "likes": 0,
+            "lang": "en"
+        },
+        {
+            "id": 41457,
+            "url": "https://assets.fanart.tv/fanart/tv/239761/tvbanner/wilfred-us-53a4da4cd2a21.jpg",
+            "likes": 0,
+            "lang": "en"
+        },
+        {
+            "id": 41458,
+            "url": "https://assets.fanart.tv/fanart/tv/239761/tvbanner/wilfred-us-53a4da6b594e5.jpg",
+            "likes": 0,
+            "lang": "en"
+        },
+        {
+            "id": 41685,
+            "url": "https://assets.fanart.tv/fanart/tv/239761/tvbanner/wilfred-us-53b7db8014425.jpg",
+            "likes": 0,
+            "lang": "en"
+        },
+        {
+            "id": 41686,
+            "url": "https://assets.fanart.tv/fanart/tv/239761/tvbanner/wilfred-us-53b7dbb922332.jpg",
+            "likes": 0,
+            "lang": "en"
+        },
+        {
+            "id": 57139,
+            "url": "https://assets.fanart.tv/fanart/tv/239761/tvbanner/wilfred-us-56071512b14d6.jpg",
+            "likes": 0,
+            "lang": "en"
+        }
+    ],
+    "season_posters": [
+        {
+            "id": 34584,
+            "url": "https://assets.fanart.tv/fanart/tv/239761/tvposter/wilfred-us-525d893230d7c.jpg",
+            "likes": 1,
+            "lang": "he"
+        }
+    ],
+    "season_banners": [
+        {
+            "id": 33755,
+            "url": "https://assets.fanart.tv/fanart/tv/239761/tvbanner/wilfred-us-52403a7185070.jpg",
+            "likes": 1,
+            "lang": "he"
+        },
+        {
+            "id": 57138,
+            "url": "https://assets.fanart.tv/fanart/tv/239761/tvbanner/wilfred-us-5607140bac1c6.jpg",
+            "likes": 1,
+            "lang": "en"
+        },
+        {
+            "id": 34716,
+            "url": "https://assets.fanart.tv/fanart/tv/239761/tvbanner/wilfred-us-5265193db51f7.jpg",
+            "likes": 0,
+            "lang": "en"
+        },
+        {
+            "id": 36389,
+            "url": "https://assets.fanart.tv/fanart/tv/239761/tvbanner/wilfred-us-52d578d57cb24.jpg",
+            "likes": 0,
+            "lang": "en"
+        },
+        {
+            "id": 36390,
+            "url": "https://assets.fanart.tv/fanart/tv/239761/tvbanner/wilfred-us-52d578de27a66.jpg",
+            "likes": 0,
+            "lang": "en"
+        },
+        {
+            "id": 41457,
+            "url": "https://assets.fanart.tv/fanart/tv/239761/tvbanner/wilfred-us-53a4da4cd2a21.jpg",
+            "likes": 0,
+            "lang": "en"
+        },
+        {
+            "id": 41458,
+            "url": "https://assets.fanart.tv/fanart/tv/239761/tvbanner/wilfred-us-53a4da6b594e5.jpg",
+            "likes": 0,
+            "lang": "en"
+        },
+        {
+            "id": 41685,
+            "url": "https://assets.fanart.tv/fanart/tv/239761/tvbanner/wilfred-us-53b7db8014425.jpg",
+            "likes": 0,
+            "lang": "en"
+        },
+        {
+            "id": 41686,
+            "url": "https://assets.fanart.tv/fanart/tv/239761/tvbanner/wilfred-us-53b7dbb922332.jpg",
+            "likes": 0,
+            "lang": "en"
+        },
+        {
+            "id": 57139,
+            "url": "https://assets.fanart.tv/fanart/tv/239761/tvbanner/wilfred-us-56071512b14d6.jpg",
+            "likes": 0,
+            "lang": "en"
+        }
+    ]
 }

--- a/fanart/tests/response/movie_thg.json
+++ b/fanart/tests/response/movie_thg.json
@@ -1,174 +1,643 @@
 {
-    "The Hunger Games": {
-        "tmdb_id": "70160",
-        "imdb_id": "tt1392170",
-        "movieart": [
-            {
-                "id": "1226",
-                "url": "http://assets.fanart.tv/fanart/movies/70160/movieart/the-hunger-games-4f6dc995edb8f.png",
-                "lang": "en",
-                "likes": "3"
-            },
-            {
-                "id": "1225",
-                "url": "http://assets.fanart.tv/fanart/movies/70160/movieart/the-hunger-games-4f6dc980b4514.png",
-                "lang": "en",
-                "likes": "1"
-            }
-        ],
-        "movielogo": [
-            {
-                "id": "1230",
-                "url": "http://assets.fanart.tv/fanart/movies/70160/movielogo/the-hunger-games-4f6e0e63a9d29.png",
-                "lang": "en",
-                "likes": "2"
-            },
-            {
-                "id": "8020",
-                "url": "http://assets.fanart.tv/fanart/movies/70160/movielogo/the-hunger-games-5018f873b5188.png",
-                "lang": "en",
-                "likes": "1"
-            },
-            {
-                "id": "1224",
-                "url": "http://assets.fanart.tv/fanart/movies/70160/movielogo/the-hunger-games-4f6dc95a08de1.png",
-                "lang": "en",
-                "likes": "0"
-            }
-        ],
-        "moviedisc": [
-            {
-                "id": "8431",
-                "url": "http://assets.fanart.tv/fanart/movies/70160/moviedisc/the-hunger-games-501db4437623f.png",
-                "lang": "en",
-                "likes": "1",
-                "disc": "1",
-                "disc_type": "dvd"
-            },
-            {
-                "id": "9787",
-                "url": "http://assets.fanart.tv/fanart/movies/70160/moviedisc/the-hunger-games-502fd6d695a60.png",
-                "lang": "en",
-                "likes": "1",
-                "disc": "1",
-                "disc_type": "bluray"
-            }
-        ],
-        "moviethumb": [
-            {
-                "id": "10687",
-                "url": "http://assets.fanart.tv/fanart/movies/70160/moviethumb/the-hunger-games-503c88b32cf66.jpg",
-                "lang": "en",
-                "likes": "0"
-            }
-        ],
-        "hdmovielogo": [
-            {
-                "id": "13004",
-                "url": "http://assets.fanart.tv/fanart/movies/70160/hdmovielogo/the-hunger-games-50500118613e3.png",
-                "lang": "en",
-                "likes": "0"
-            }
-        ],
-        "moviebackground": [
-            {
-                "id": "14043",
-                "url": "http://assets.fanart.tv/fanart/movies/70160/moviebackground/the-hunger-games-5057c79ad3c56.jpg",
-                "lang": "en",
-                "likes": "0"
-            },
-            {
-                "id": "14044",
-                "url": "http://assets.fanart.tv/fanart/movies/70160/moviebackground/the-hunger-games-5057c79ad5526.jpg",
-                "lang": "en",
-                "likes": "0"
-            },
-            {
-                "id": "15911",
-                "url": "http://assets.fanart.tv/fanart/movies/70160/moviebackground/the-hunger-games-5071de49311d1.jpg",
-                "lang": "en",
-                "likes": "0"
-            },
-            {
-                "id": "15914",
-                "url": "http://assets.fanart.tv/fanart/movies/70160/moviebackground/the-hunger-games-5071df619b835.jpg",
-                "lang": "en",
-                "likes": "0"
-            },
-            {
-                "id": "15917",
-                "url": "http://assets.fanart.tv/fanart/movies/70160/moviebackground/the-hunger-games-5071e01fee856.jpg",
-                "lang": "en",
-                "likes": "0"
-            },
-            {
-                "id": "15918",
-                "url": "http://assets.fanart.tv/fanart/movies/70160/moviebackground/the-hunger-games-5071e0adcc57a.jpg",
-                "lang": "en",
-                "likes": "0"
-            },
-            {
-                "id": "15919",
-                "url": "http://assets.fanart.tv/fanart/movies/70160/moviebackground/the-hunger-games-5071e12006159.jpg",
-                "lang": "en",
-                "likes": "0"
-            },
-            {
-                "id": "15921",
-                "url": "http://assets.fanart.tv/fanart/movies/70160/moviebackground/the-hunger-games-5071e206aa2ac.jpg",
-                "lang": "en",
-                "likes": "0"
-            },
-            {
-                "id": "15922",
-                "url": "http://assets.fanart.tv/fanart/movies/70160/moviebackground/the-hunger-games-5071e2869d774.jpg",
-                "lang": "en",
-                "likes": "0"
-            },
-            {
-                "id": "15925",
-                "url": "http://assets.fanart.tv/fanart/movies/70160/moviebackground/the-hunger-games-5071e30069b72.jpg",
-                "lang": "en",
-                "likes": "0"
-            },
-            {
-                "id": "15927",
-                "url": "http://assets.fanart.tv/fanart/movies/70160/moviebackground/the-hunger-games-5071e3c4979b7.jpg",
-                "lang": "en",
-                "likes": "0"
-            },
-            {
-                "id": "15930",
-                "url": "http://assets.fanart.tv/fanart/movies/70160/moviebackground/the-hunger-games-5071e5b3f039b.jpg",
-                "lang": "en",
-                "likes": "0"
-            },
-            {
-                "id": "15931",
-                "url": "http://assets.fanart.tv/fanart/movies/70160/moviebackground/the-hunger-games-5071e6369e812.jpg",
-                "lang": "en",
-                "likes": "0"
-            },
-            {
-                "id": "15936",
-                "url": "http://assets.fanart.tv/fanart/movies/70160/moviebackground/the-hunger-games-5071e8749e73a.jpg",
-                "lang": "en",
-                "likes": "0"
-            },
-            {
-                "id": "15937",
-                "url": "http://assets.fanart.tv/fanart/movies/70160/moviebackground/the-hunger-games-5071e9913bfeb.jpg",
-                "lang": "en",
-                "likes": "0"
-            }
-        ],
-        "hdmovieclearart": [
-            {
-                "id": "14104",
-                "url": "http://assets.fanart.tv/fanart/movies/70160/hdmovieclearart/the-hunger-games-50582453b1375.png",
-                "lang": "en",
-                "likes": "0"
-            }
-        ]
-    }
+    "name": "The Hunger Games",
+    "tmdb_id": "70160",
+    "imdb_id": "tt1392170",
+    "hdmovielogo": [
+        {
+            "id": "57659",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/hdmovielogo/the-hunger-games-528f5039e0952.png",
+            "lang": "en",
+            "likes": "11"
+        },
+        {
+            "id": "57687",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/hdmovielogo/the-hunger-games-528f7e2ac443b.png",
+            "lang": "en",
+            "likes": "7"
+        },
+        {
+            "id": "57519",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/hdmovielogo/the-hunger-games-528e559d3b417.png",
+            "lang": "fr",
+            "likes": "7"
+        },
+        {
+            "id": "57688",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/hdmovielogo/the-hunger-games-528f7e3e86057.png",
+            "lang": "fr",
+            "likes": "4"
+        },
+        {
+            "id": "67088",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/hdmovielogo/the-hunger-games-5325b5e6b9d98.png",
+            "lang": "es",
+            "likes": "2"
+        },
+        {
+            "id": "57657",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/hdmovielogo/the-hunger-games-528f48e712885.png",
+            "lang": "de",
+            "likes": "2"
+        },
+        {
+            "id": "57686",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/hdmovielogo/the-hunger-games-528f7e1420556.png",
+            "lang": "de",
+            "likes": "2"
+        },
+        {
+            "id": "153458",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/hdmovielogo/the-hunger-games-573f577d2629a.png",
+            "lang": "pl",
+            "likes": "1"
+        },
+        {
+            "id": "153530",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/hdmovielogo/the-hunger-games-573f87f11ff6f.png",
+            "lang": "pl",
+            "likes": "1"
+        },
+        {
+            "id": "153546",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/hdmovielogo/the-hunger-games-5740179f7f08a.png",
+            "lang": "pl",
+            "likes": "1"
+        },
+        {
+            "id": "58172",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/hdmovielogo/the-hunger-games-5296dd1494834.png",
+            "lang": "ru",
+            "likes": "0"
+        },
+        {
+            "id": "58173",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/hdmovielogo/the-hunger-games-5296dd22a7d2a.png",
+            "lang": "ru",
+            "likes": "0"
+        }
+    ],
+    "hdmovieclearart": [
+        {
+            "id": "58177",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/hdmovieclearart/the-hunger-games-5296dda1af66e.png",
+            "lang": "en",
+            "likes": "8"
+        },
+        {
+            "id": "57718",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/hdmovieclearart/the-hunger-games-528fccd9afa08.png",
+            "lang": "fr",
+            "likes": "4"
+        },
+        {
+            "id": "138395",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/hdmovieclearart/the-hunger-games-56c3bd2f426a2.png",
+            "lang": "es",
+            "likes": "3"
+        },
+        {
+            "id": "14104",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/hdmovieclearart/the-hunger-games-50582453b1375.png",
+            "lang": "en",
+            "likes": "1"
+        },
+        {
+            "id": "36754",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/hdmovieclearart/the-hunger-games-51a76f9b35b68.png",
+            "lang": "en",
+            "likes": "1"
+        },
+        {
+            "id": "26534",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/hdmovieclearart/the-hunger-games-513643b6879c0.png",
+            "lang": "pl",
+            "likes": "1"
+        },
+        {
+            "id": "55612",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/hdmovieclearart/the-hunger-games-5273f46398443.png",
+            "lang": "de",
+            "likes": "0"
+        },
+        {
+            "id": "55613",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/hdmovieclearart/the-hunger-games-5273f46398b85.png",
+            "lang": "de",
+            "likes": "0"
+        },
+        {
+            "id": "55614",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/hdmovieclearart/the-hunger-games-5273f47ddc1aa.png",
+            "lang": "pl",
+            "likes": "0"
+        },
+        {
+            "id": "55615",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/hdmovieclearart/the-hunger-games-5273f47ddcb0d.png",
+            "lang": "pl",
+            "likes": "0"
+        },
+        {
+            "id": "55616",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/hdmovieclearart/the-hunger-games-5273f499b2efe.png",
+            "lang": "en",
+            "likes": "0"
+        },
+        {
+            "id": "58176",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/hdmovieclearart/the-hunger-games-5296dd8ad1105.png",
+            "lang": "ru",
+            "likes": "0"
+        },
+        {
+            "id": "55617",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/hdmovieclearart/the-hunger-games-5273f499b35c8.png",
+            "lang": "en",
+            "likes": "0"
+        },
+        {
+            "id": "26539",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/hdmovieclearart/the-hunger-games-5136534a62a4e.png",
+            "lang": "pl",
+            "likes": "0"
+        }
+    ],
+    "moviedisc": [
+        {
+            "id": "26728",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/moviedisc/the-hunger-games-5139a08c09956.png",
+            "lang": "en",
+            "likes": "7",
+            "disc": "1",
+            "disc_type": "bluray"
+        },
+        {
+            "id": "85058",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/moviedisc/the-hunger-games-5431702449d26.png",
+            "lang": "fr",
+            "likes": "6",
+            "disc": "1",
+            "disc_type": "bluray"
+        },
+        {
+            "id": "93048",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/moviedisc/the-hunger-games-54a48d1f50a3b.png",
+            "lang": "en",
+            "likes": "6",
+            "disc": "1",
+            "disc_type": "bluray"
+        },
+        {
+            "id": "85057",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/moviedisc/the-hunger-games-54317005eb45e.png",
+            "lang": "en",
+            "likes": "5",
+            "disc": "1",
+            "disc_type": "bluray"
+        },
+        {
+            "id": "142709",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/moviedisc/the-hunger-games-56e43b138db23.png",
+            "lang": "en",
+            "likes": "4",
+            "disc": "1",
+            "disc_type": "bluray"
+        },
+        {
+            "id": "8431",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/moviedisc/the-hunger-games-501db4437623f.png",
+            "lang": "en",
+            "likes": "4",
+            "disc": "1",
+            "disc_type": "dvd"
+        },
+        {
+            "id": "93054",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/moviedisc/the-hunger-games-54a49bd5af0b9.png",
+            "lang": "en",
+            "likes": "3",
+            "disc": "1",
+            "disc_type": "bluray"
+        },
+        {
+            "id": "122835",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/moviedisc/the-hunger-games-5607b3241fc8a.png",
+            "lang": "es",
+            "likes": "3",
+            "disc": "1",
+            "disc_type": "bluray"
+        },
+        {
+            "id": "9787",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/moviedisc/the-hunger-games-502fd6d695a60.png",
+            "lang": "en",
+            "likes": "2",
+            "disc": "1",
+            "disc_type": "bluray"
+        },
+        {
+            "id": "99861",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/moviedisc/the-hunger-games-54fc56a87f8e1.png",
+            "lang": "de",
+            "likes": "1",
+            "disc": "1",
+            "disc_type": "bluray"
+        },
+        {
+            "id": "35016",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/moviedisc/the-hunger-games-519554a51d708.png",
+            "lang": "de",
+            "likes": "1",
+            "disc": "1",
+            "disc_type": "bluray"
+        },
+        {
+            "id": "85059",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/moviedisc/the-hunger-games-5431704438eb6.png",
+            "lang": "de",
+            "likes": "0",
+            "disc": "1",
+            "disc_type": "bluray"
+        },
+        {
+            "id": "85060",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/moviedisc/the-hunger-games-54317064bf8fb.png",
+            "lang": "ru",
+            "likes": "0",
+            "disc": "1",
+            "disc_type": "bluray"
+        }
+    ],
+    "movieposter": [
+        {
+            "id": "52850",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/movieposter/the-hunger-games-52497d189110b.jpg",
+            "lang": "en",
+            "likes": "7"
+        },
+        {
+            "id": "58174",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/movieposter/the-hunger-games-5296dd471d639.jpg",
+            "lang": "00",
+            "likes": "6"
+        },
+        {
+            "id": "99774",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/movieposter/the-hunger-games-54fb39df92832.jpg",
+            "lang": "en",
+            "likes": "6"
+        },
+        {
+            "id": "93052",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/movieposter/the-hunger-games-54a494cda1840.jpg",
+            "lang": "00",
+            "likes": "4"
+        },
+        {
+            "id": "218233",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/movieposter/the-hunger-games-5a7f8a078c90e.jpg",
+            "lang": "es",
+            "likes": "3"
+        },
+        {
+            "id": "218234",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/movieposter/the-hunger-games-5a7f8a16ec046.jpg",
+            "lang": "es",
+            "likes": "3"
+        },
+        {
+            "id": "93053",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/movieposter/the-hunger-games-54a494cda2176.jpg",
+            "lang": "00",
+            "likes": "2"
+        },
+        {
+            "id": "74735",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/movieposter/the-hunger-games-53b119c0100fc.jpg",
+            "lang": "fr",
+            "likes": "2"
+        },
+        {
+            "id": "68608",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/movieposter/the-hunger-games-5335a39219806.jpg",
+            "lang": "de",
+            "likes": "1"
+        },
+        {
+            "id": "142620",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/movieposter/the-hunger-games-56e32926f255a.jpg",
+            "lang": "fr",
+            "likes": "1"
+        },
+        {
+            "id": "58175",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/movieposter/the-hunger-games-5296dd62a8d38.jpg",
+            "lang": "ru",
+            "likes": "1"
+        },
+        {
+            "id": "93051",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/movieposter/the-hunger-games-54a494cda0922.jpg",
+            "lang": "00",
+            "likes": "1"
+        },
+        {
+            "id": "171203",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/movieposter/the-hunger-games-5831e4f72df33.jpg",
+            "lang": "en",
+            "likes": "1"
+        },
+        {
+            "id": "171204",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/movieposter/the-hunger-games-5831e4f72eb10.jpg",
+            "lang": "en",
+            "likes": "1"
+        },
+        {
+            "id": "171205",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/movieposter/the-hunger-games-5831e4f72f130.jpg",
+            "lang": "en",
+            "likes": "1"
+        },
+        {
+            "id": "171206",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/movieposter/the-hunger-games-5831e4f72f6b9.jpg",
+            "lang": "en",
+            "likes": "1"
+        },
+        {
+            "id": "153550",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/movieposter/the-hunger-games-574027c50b23a.jpg",
+            "lang": "pl",
+            "likes": "1"
+        },
+        {
+            "id": "153551",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/movieposter/the-hunger-games-574027c50bac9.jpg",
+            "lang": "pl",
+            "likes": "1"
+        },
+        {
+            "id": "153552",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/movieposter/the-hunger-games-574027c50c00d.jpg",
+            "lang": "pl",
+            "likes": "1"
+        },
+        {
+            "id": "142619",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/movieposter/the-hunger-games-56e3291171ee2.jpg",
+            "lang": "fr",
+            "likes": "0"
+        },
+        {
+            "id": "62784",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/movieposter/the-hunger-games-52e6a9036c84f.jpg",
+            "lang": "en",
+            "likes": "0"
+        },
+        {
+            "id": "154795",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/movieposter/the-hunger-games-57500557a49a1.jpg",
+            "lang": "de",
+            "likes": "0"
+        }
+    ],
+    "movieart": [
+        {
+            "id": "1226",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/movieart/the-hunger-games-4f6dc995edb8f.png",
+            "lang": "en",
+            "likes": "4"
+        },
+        {
+            "id": "1225",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/movieart/the-hunger-games-4f6dc980b4514.png",
+            "lang": "en",
+            "likes": "2"
+        }
+    ],
+    "movielogo": [
+        {
+            "id": "8020",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/movielogo/the-hunger-games-5018f873b5188.png",
+            "lang": "en",
+            "likes": "3"
+        },
+        {
+            "id": "1230",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/movielogo/the-hunger-games-4f6e0e63a9d29.png",
+            "lang": "en",
+            "likes": "2"
+        },
+        {
+            "id": "1224",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/movielogo/the-hunger-games-4f6dc95a08de1.png",
+            "lang": "en",
+            "likes": "1"
+        }
+    ],
+    "moviethumb": [
+        {
+            "id": "63582",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/moviethumb/the-hunger-games-52f19dd4dc531.jpg",
+            "lang": "en",
+            "likes": "3"
+        },
+        {
+            "id": "10687",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/moviethumb/the-hunger-games-503c88b32cf66.jpg",
+            "lang": "en",
+            "likes": "3"
+        },
+        {
+            "id": "138365",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/moviethumb/the-hunger-games-56c387040943b.jpg",
+            "lang": "es",
+            "likes": "2"
+        },
+        {
+            "id": "138366",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/moviethumb/the-hunger-games-56c3870f3b889.jpg",
+            "lang": "es",
+            "likes": "2"
+        },
+        {
+            "id": "136921",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/moviethumb/the-hunger-games-56b4ecdb4cb66.jpg",
+            "lang": "fr",
+            "likes": "1"
+        },
+        {
+            "id": "53391",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/moviethumb/the-hunger-games-5251d9706cf40.jpg",
+            "lang": "de",
+            "likes": "0"
+        },
+        {
+            "id": "53392",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/moviethumb/the-hunger-games-5251d97d2bc96.jpg",
+            "lang": "en",
+            "likes": "0"
+        },
+        {
+            "id": "136920",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/moviethumb/the-hunger-games-56b4ecdb4c45f.jpg",
+            "lang": "fr",
+            "likes": "0"
+        }
+    ],
+    "moviebackground": [
+        {
+            "id": "15919",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/moviebackground/the-hunger-games-5071e12006159.jpg",
+            "lang": "",
+            "likes": "2"
+        },
+        {
+            "id": "15921",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/moviebackground/the-hunger-games-5071e206aa2ac.jpg",
+            "lang": "",
+            "likes": "2"
+        },
+        {
+            "id": "15922",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/moviebackground/the-hunger-games-5071e2869d774.jpg",
+            "lang": "",
+            "likes": "2"
+        },
+        {
+            "id": "15925",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/moviebackground/the-hunger-games-5071e30069b72.jpg",
+            "lang": "",
+            "likes": "2"
+        },
+        {
+            "id": "15927",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/moviebackground/the-hunger-games-5071e3c4979b7.jpg",
+            "lang": "",
+            "likes": "2"
+        },
+        {
+            "id": "15930",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/moviebackground/the-hunger-games-5071e5b3f039b.jpg",
+            "lang": "",
+            "likes": "2"
+        },
+        {
+            "id": "15931",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/moviebackground/the-hunger-games-5071e6369e812.jpg",
+            "lang": "",
+            "likes": "2"
+        },
+        {
+            "id": "15936",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/moviebackground/the-hunger-games-5071e8749e73a.jpg",
+            "lang": "",
+            "likes": "2"
+        },
+        {
+            "id": "15937",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/moviebackground/the-hunger-games-5071e9913bfeb.jpg",
+            "lang": "",
+            "likes": "2"
+        },
+        {
+            "id": "142658",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/moviebackground/the-hunger-games-56e3efb2adbd7.jpg",
+            "lang": "",
+            "likes": "2"
+        },
+        {
+            "id": "142659",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/moviebackground/the-hunger-games-56e3efb2af62f.jpg",
+            "lang": "",
+            "likes": "2"
+        },
+        {
+            "id": "14043",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/moviebackground/the-hunger-games-5057c79ad3c56.jpg",
+            "lang": "",
+            "likes": "2"
+        },
+        {
+            "id": "14044",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/moviebackground/the-hunger-games-5057c79ad5526.jpg",
+            "lang": "",
+            "likes": "2"
+        },
+        {
+            "id": "24822",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/moviebackground/the-hunger-games-51208e3788477.jpg",
+            "lang": "",
+            "likes": "2"
+        },
+        {
+            "id": "15911",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/moviebackground/the-hunger-games-5071de49311d1.jpg",
+            "lang": "",
+            "likes": "1"
+        },
+        {
+            "id": "15914",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/moviebackground/the-hunger-games-5071df619b835.jpg",
+            "lang": "",
+            "likes": "1"
+        },
+        {
+            "id": "15917",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/moviebackground/the-hunger-games-5071e01fee856.jpg",
+            "lang": "",
+            "likes": "1"
+        },
+        {
+            "id": "15918",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/moviebackground/the-hunger-games-5071e0adcc57a.jpg",
+            "lang": "",
+            "likes": "1"
+        },
+        {
+            "id": "24823",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/moviebackground/the-hunger-games-51208f2b8b580.jpg",
+            "lang": "",
+            "likes": "1"
+        }
+    ],
+    "moviebanner": [
+        {
+            "id": "28528",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/moviebanner/the-hunger-games-514ec04ad47de.jpg",
+            "lang": "en",
+            "likes": "2"
+        },
+        {
+            "id": "138364",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/moviebanner/the-hunger-games-56c386f7f149b.jpg",
+            "lang": "es",
+            "likes": "2"
+        },
+        {
+            "id": "136919",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/moviebanner/the-hunger-games-56b4ecc453ffb.jpg",
+            "lang": "fr",
+            "likes": "1"
+        },
+        {
+            "id": "122241",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/moviebanner/the-hunger-games-56008d6a4885e.jpg",
+            "lang": "en",
+            "likes": "0"
+        },
+        {
+            "id": "53393",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/moviebanner/the-hunger-games-5251da676190e.jpg",
+            "lang": "de",
+            "likes": "0"
+        },
+        {
+            "id": "136918",
+            "url": "https://assets.fanart.tv/fanart/movies/70160/moviebanner/the-hunger-games-56b4ecc453971.jpg",
+            "lang": "fr",
+            "likes": "0"
+        }
+    ]
 }

--- a/fanart/tests/response/music_a7f.json
+++ b/fanart/tests/response/music_a7f.json
@@ -1,171 +1,648 @@
 {
-    "Avenged Sevenfold": {
-        "mbid_id": "24e1b53c-3085-4581-8472-0b0088d2508c",
-        "artistbackground": [
-            {
-                "id": "3027",
-                "url": "http://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/artistbackground/avenged-sevenfold-4ddd7889a0fcf.jpg",
-                "likes": "0"
-            },
-            {
-                "id": "64046",
-                "url": "http://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/artistbackground/avenged-sevenfold-50c4db9a2c6e2.jpg",
-                "likes": "0"
-            },
-            {
-                "id": "64048",
-                "url": "http://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/artistbackground/avenged-sevenfold-50c4dc653f004.jpg",
-                "likes": "0"
-            }
-        ],
-        "albums": {
-            "180560ee-2d9d-33cf-8de7-cdaaba610739": {
-                "albumcover": [
-                    {
-                        "id": "3028",
-                        "url": "http://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/albumcover/city-of-evil-4ddd79ca0beea.jpg",
-                        "likes": "0"
-                    }
-                ],
-                "cdart": [
-                    {
-                        "id": "9921",
-                        "url": "http://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/cdart/city-of-evil-4e5f7b9f50d37.png",
-                        "likes": "0",
-                        "disc": "1",
-                        "size": "1000"
-                    }
-                ]
-            },
-            "1c7120ae-32b6-3693-8974-599977b01601": {
-                "albumcover": [
-                    {
-                        "id": "3029",
-                        "url": "http://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/albumcover/waking-the-fallen-4ddd79ca1b11e.jpg",
-                        "likes": "0"
-                    }
-                ],
-                "cdart": [
-                    {
-                        "id": "9922",
-                        "url": "http://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/cdart/waking-the-fallen-4e5f7b9f5ebdf.png",
-                        "likes": "0",
-                        "disc": "1",
-                        "size": "1000"
-                    }
-                ]
-            },
-            "94672194-7f42-3965-a489-f2f3cdc1c79e": {
-                "albumcover": [
-                    {
-                        "id": "3030",
-                        "url": "http://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/albumcover/avenged-sevenfold-4ddd79ca1bcd6.jpg",
-                        "likes": "0"
-                    }
-                ],
-                "cdart": [
-                    {
-                        "id": "9923",
-                        "url": "http://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/cdart/avenged-sevenfold-4e5f7b9f5fb7f.png",
-                        "likes": "0",
-                        "disc": "1",
-                        "size": "1000"
-                    }
-                ]
-            },
-            "9d642393-0005-3e89-b3d4-35d89c2f6ad6": {
-                "albumcover": [
-                    {
-                        "id": "3031",
-                        "url": "http://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/albumcover/sounding-the-seventh-trumpet-4ddd79ca1d05e.jpg",
-                        "likes": "0"
-                    }
-                ],
-                "cdart": [
-                    {
-                        "id": "9924",
-                        "url": "http://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/cdart/sounding-the-seventh-trumpet-4e5f7b9f62e47.png",
-                        "likes": "0",
-                        "disc": "1",
-                        "size": "1000"
-                    }
-                ]
-            },
-            "fe4373ed-5e89-46b3-b4c0-31433ce217df": {
-                "albumcover": [
-                    {
-                        "id": "3032",
-                        "url": "http://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/albumcover/nightmare-4ddd79ca1dffe.jpg",
-                        "likes": "0"
-                    }
-                ],
-                "cdart": [
-                    {
-                        "id": "11630",
-                        "url": "http://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/cdart/nightmare-4e8059a3c581c.png",
-                        "likes": "0",
-                        "disc": "1",
-                        "size": "1000"
-                    }
-                ]
-            },
-            "41d1b72b-1eee-3319-937f-c85d6d2fcfbb": {
-                "albumcover": [
-                    {
-                        "id": "61014",
-                        "url": "http://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/albumcover/warmness-on-the-soul-509d2e9150bf4.jpg",
-                        "likes": "0"
-                    }
-                ]
-            }
+    "name": "Avenged Sevenfold",
+    "mbid_id": "24e1b53c-3085-4581-8472-0b0088d2508c",
+    "albums": {
+        "fe4373ed-5e89-46b3-b4c0-31433ce217df": {
+            "albumcover": [
+                {
+                    "id": "128441",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/albumcover/nightmare-53b398b4d032e.jpg",
+                    "likes": "4"
+                },
+                {
+                    "id": "128499",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/albumcover/nightmare-53b4103e89cb1.jpg",
+                    "likes": "1"
+                },
+                {
+                    "id": "251000",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/albumcover/nightmare-5be54c7b03578.jpg",
+                    "likes": "0"
+                }
+            ],
+            "cdart": [
+                {
+                    "id": "11630",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/cdart/nightmare-4e8059a3c581c.png",
+                    "likes": "2",
+                    "disc": "1",
+                    "size": "1000"
+                }
+            ]
         },
-        "musiclogo": [
-            {
-                "id": "5712",
-                "url": "http://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/musiclogo/avenged-sevenfold-4dfc8aee78b49.png",
-                "likes": "0"
-            },
-            {
-                "id": "41835",
-                "url": "http://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/musiclogo/avenged-sevenfold-4ffc75f3a7e54.png",
-                "likes": "0"
-            },
-            {
-                "id": "41836",
-                "url": "http://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/musiclogo/avenged-sevenfold-4ffc75f3a8473.png",
-                "likes": "0"
-            }
-        ],
-        "artistthumb": [
-            {
-                "id": "31109",
-                "url": "http://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/artistthumb/avenged-sevenfold-4fb2b533bc73a.jpg",
-                "likes": "0"
-            },
-            {
-                "id": "64042",
-                "url": "http://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/artistthumb/avenged-sevenfold-50c4d9279d6e9.jpg",
-                "likes": "0"
-            }
-        ],
-        "hdmusiclogo": [
-            {
-                "id": "49644",
-                "url": "http://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/hdmusiclogo/avenged-sevenfold-503fcebece042.png",
-                "likes": "0"
-            },
-            {
-                "id": "49645",
-                "url": "http://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/hdmusiclogo/avenged-sevenfold-503fcebecf17e.png",
-                "likes": "0"
-            }
-        ],
-        "musicbanner": [
-            {
-                "id": "52630",
-                "url": "http://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/musicbanner/avenged-sevenfold-505b2346a559d.jpg",
-                "likes": "0"
-            }
-        ]
-    }
+        "6937c4d3-ecf8-3464-8453-9f3a86dbecef": {
+            "albumcover": [
+                {
+                    "id": "190903",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/albumcover/live-in-the-lbc--diamonds-in-the-rough-56daab95340aa.jpg",
+                    "likes": "3"
+                },
+                {
+                    "id": "249974",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/albumcover/live-in-the-lbc--diamonds-in-the-rough-5bcd0ee12eecc.jpg",
+                    "likes": "2"
+                },
+                {
+                    "id": "102876",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/albumcover/live-in-the-lbc--diamonds-in-the-rough-526fdf214a2ba.jpg",
+                    "likes": "0"
+                }
+            ],
+            "cdart": [
+                {
+                    "id": "105723",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/cdart/live-in-the-lbc--diamonds-in-the-rough-5296c531b6370.png",
+                    "likes": "0",
+                    "disc": "1",
+                    "size": "1000"
+                }
+            ]
+        },
+        "94672194-7f42-3965-a489-f2f3cdc1c79e": {
+            "albumcover": [
+                {
+                    "id": "128449",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/albumcover/avenged-sevenfold-53b3b73b9800f.jpg",
+                    "likes": "3"
+                },
+                {
+                    "id": "128450",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/albumcover/avenged-sevenfold-53b3b749894c6.jpg",
+                    "likes": "1"
+                }
+            ],
+            "cdart": [
+                {
+                    "id": "9923",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/cdart/avenged-sevenfold-4e5f7b9f5fb7f.png",
+                    "likes": "0",
+                    "disc": "1",
+                    "size": "1000"
+                }
+            ]
+        },
+        "180560ee-2d9d-33cf-8de7-cdaaba610739": {
+            "albumcover": [
+                {
+                    "id": "128493",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/albumcover/city-of-evil-53b40f8f72620.jpg",
+                    "likes": "3"
+                },
+                {
+                    "id": "168354",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/albumcover/city-of-evil-559316eeccee8.jpg",
+                    "likes": "1"
+                },
+                {
+                    "id": "128494",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/albumcover/city-of-evil-53b40fa5e5385.jpg",
+                    "likes": "1"
+                },
+                {
+                    "id": "250863",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/albumcover/city-of-evil-5be135ee3e6c7.jpg",
+                    "likes": "0"
+                }
+            ],
+            "cdart": [
+                {
+                    "id": "9921",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/cdart/city-of-evil-4e5f7b9f50d37.png",
+                    "likes": "0",
+                    "disc": "1",
+                    "size": "1000"
+                }
+            ]
+        },
+        "6f7e9796-bec7-4b79-aa6a-27db027f5c57": {
+            "albumcover": [
+                {
+                    "id": "205688",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/albumcover/the-stage-581358402bb49.jpg",
+                    "likes": "2"
+                },
+                {
+                    "id": "249971",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/albumcover/the-stage-5bcd0e5ef1df7.jpg",
+                    "likes": "1"
+                },
+                {
+                    "id": "249975",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/albumcover/the-stage-5bcd0ee132ed4.jpg",
+                    "likes": "1"
+                },
+                {
+                    "id": "230472",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/albumcover/the-stage-5a134ebfa84d0.jpg",
+                    "likes": "0"
+                }
+            ]
+        },
+        "e7ea84a1-bf34-43f9-a421-af93624b708f": {
+            "albumcover": [
+                {
+                    "id": "249976",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/albumcover/all-excess-5bcd101139bc6.jpg",
+                    "likes": "2"
+                },
+                {
+                    "id": "128401",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/albumcover/all-excess-53b3086f398d7.jpg",
+                    "likes": "1"
+                }
+            ]
+        },
+        "78b8223a-8ba3-403e-bea6-63be9f378716": {
+            "albumcover": [
+                {
+                    "id": "249977",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/albumcover/critical-acclaim-5bcd114adbe6c.jpg",
+                    "likes": "2"
+                },
+                {
+                    "id": "131968",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/albumcover/critical-acclaim-53e65d0ba7dab.jpg",
+                    "likes": "0"
+                }
+            ]
+        },
+        "46303229-3ef4-480d-b648-a78e1c64c911": {
+            "albumcover": [
+                {
+                    "id": "128895",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/albumcover/hail-to-the-king-53b8592f20a8a.jpg",
+                    "likes": "2"
+                },
+                {
+                    "id": "128896",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/albumcover/hail-to-the-king-53b85946c4a9a.jpg",
+                    "likes": "2"
+                },
+                {
+                    "id": "190904",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/albumcover/hail-to-the-king-56daabbf72f39.jpg",
+                    "likes": "2"
+                },
+                {
+                    "id": "128495",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/albumcover/hail-to-the-king-53b40fdfce251.jpg",
+                    "likes": "2"
+                },
+                {
+                    "id": "128898",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/albumcover/hail-to-the-king-53b85961c471f.jpg",
+                    "likes": "1"
+                }
+            ],
+            "cdart": [
+                {
+                    "id": "101408",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/cdart/hail-to-the-king-525c4d2d69b27.png",
+                    "likes": "1",
+                    "disc": "1",
+                    "size": "1000"
+                },
+                {
+                    "id": "98963",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/cdart/hail-to-the-king-523da0068ff85.png",
+                    "likes": "0",
+                    "disc": "1",
+                    "size": "1000"
+                }
+            ]
+        },
+        "9d642393-0005-3e89-b3d4-35d89c2f6ad6": {
+            "albumcover": [
+                {
+                    "id": "128403",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/albumcover/sounding-the-seventh-trumpet-53b308d7bea26.jpg",
+                    "likes": "2"
+                },
+                {
+                    "id": "3031",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/albumcover/sounding-the-seventh-trumpet-4ddd79ca1d05e.jpg",
+                    "likes": "1"
+                },
+                {
+                    "id": "250992",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/albumcover/sounding-the-seventh-trumpet-5be53d28d601e.jpg",
+                    "likes": "0"
+                }
+            ],
+            "cdart": [
+                {
+                    "id": "105693",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/cdart/sounding-the-seventh-trumpet-529649562b8bf.png",
+                    "likes": "2",
+                    "disc": "1",
+                    "size": "1000"
+                }
+            ]
+        },
+        "1c7120ae-32b6-3693-8974-599977b01601": {
+            "albumcover": [
+                {
+                    "id": "128452",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/albumcover/waking-the-fallen-53b3b83b67dbe.jpg",
+                    "likes": "2"
+                },
+                {
+                    "id": "131878",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/albumcover/waking-the-fallen-53e524aeb7a1b.jpg",
+                    "likes": "1"
+                },
+                {
+                    "id": "249972",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/albumcover/waking-the-fallen-5bcd0e5f03053.jpg",
+                    "likes": "1"
+                }
+            ],
+            "cdart": [
+                {
+                    "id": "9922",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/cdart/waking-the-fallen-4e5f7b9f5ebdf.png",
+                    "likes": "0",
+                    "disc": "1",
+                    "size": "1000"
+                }
+            ]
+        },
+        "46633632-801d-4f4d-8c5b-0d2a207ae2f8": {
+            "albumcover": [
+                {
+                    "id": "128492",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/albumcover/carry-on-call-of-duty-black-ops-ii-version-53b40f6ebbf21.jpg",
+                    "likes": "2"
+                },
+                {
+                    "id": "190902",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/albumcover/carry-on-call-of-duty-black-ops-ii-version-56daa99ff2f13.jpg",
+                    "likes": "1"
+                }
+            ]
+        },
+        "04576112-0cb5-381e-85f8-9020939de1a9": {
+            "albumcover": [
+                {
+                    "id": "129360",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/albumcover/beast-and-the-harlot-53bc6579556f5.jpg",
+                    "likes": "1"
+                }
+            ]
+        },
+        "7a64c494-4652-4577-93b3-0d6090f2473e": {
+            "albumcover": [
+                {
+                    "id": "180078",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/albumcover/hail-to-the-king-deathbat-original-video-game-soundtrack-560ceef32e364.jpg",
+                    "likes": "1"
+                }
+            ]
+        },
+        "b47f833c-f496-4a00-b9c4-7336a04fb867": {
+            "albumcover": [
+                {
+                    "id": "249966",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/albumcover/as-tears-go-by-5bcd0e5ed3742.jpg",
+                    "likes": "1"
+                }
+            ]
+        },
+        "811001d5-88bb-4ba2-bcef-05827d85d4f1": {
+            "albumcover": [
+                {
+                    "id": "249967",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/albumcover/dose-5bcd0e5ed762d.jpg",
+                    "likes": "1"
+                }
+            ]
+        },
+        "e0344128-b071-48eb-b420-3c5f8d9ea8cd": {
+            "albumcover": [
+                {
+                    "id": "249968",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/albumcover/god-only-knows-5bcd0e5edf7ca.jpg",
+                    "likes": "1"
+                }
+            ]
+        },
+        "d041c6c1-0829-4f6e-a69e-8e29ad004860": {
+            "albumcover": [
+                {
+                    "id": "249969",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/albumcover/mad-hatter-5bcd0e5ee776d.jpg",
+                    "likes": "1"
+                }
+            ]
+        },
+        "02ff3ae6-89b9-4a14-a147-d86e80a4cdad": {
+            "albumcover": [
+                {
+                    "id": "249970",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/albumcover/malaguea-salerosa-la-malaguea-5bcd0e5eeb939.jpg",
+                    "likes": "1"
+                }
+            ]
+        },
+        "123d6c7f-d26a-4b94-a79e-fcdec59ec0b9": {
+            "albumcover": [
+                {
+                    "id": "249973",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/albumcover/wish-you-were-here-5bcd0e5f079fc.jpg",
+                    "likes": "1"
+                }
+            ]
+        },
+        "5ddff4f2-c053-46ee-b785-180c06e5dd97": {
+            "albumcover": [
+                {
+                    "id": "249979",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/albumcover/the-best-of-2005-2013-5bcd16939221d.jpg",
+                    "likes": "1"
+                }
+            ]
+        },
+        "87c98289-1b38-4eb3-baf5-eb9f6f5a165d": {
+            "albumcover": [
+                {
+                    "id": "249980",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/albumcover/shepherd-of-fire-5bcd179e54c3b.jpg",
+                    "likes": "1"
+                }
+            ]
+        },
+        "adaa4143-984e-48a6-a94a-b8f48ea19614": {
+            "albumcover": [
+                {
+                    "id": "128899",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/albumcover/not-ready-to-die-from-call-of-the-dead-53b8597c550fd.jpg",
+                    "likes": "1"
+                }
+            ]
+        },
+        "7f017b86-bd88-3ed2-a16f-19d6427c423a": {
+            "albumcover": [
+                {
+                    "id": "128402",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/albumcover/walk-53b3089985c9f.jpg",
+                    "likes": "1"
+                }
+            ]
+        },
+        "fbbcda22-58a8-44fd-972d-e4d25e18e544": {
+            "albumcover": [
+                {
+                    "id": "129203",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/albumcover/so-far-away-53bac4f31dd95.jpg",
+                    "likes": "1"
+                }
+            ]
+        },
+        "f674046a-ea6e-4af5-a04e-82263702ec8d": {
+            "albumcover": [
+                {
+                    "id": "129204",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/albumcover/nightmare-53bac5ee6506d.jpg",
+                    "likes": "1"
+                }
+            ]
+        },
+        "da8d77cd-dd26-4356-86f9-9fe45b25f799": {
+            "albumcover": [
+                {
+                    "id": "129206",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/albumcover/crossroads-53bac65f5d21a.jpg",
+                    "likes": "1"
+                }
+            ]
+        },
+        "6292ac51-7acc-341c-a00a-bab0f21ab01b": {
+            "albumcover": [
+                {
+                    "id": "129207",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/albumcover/dear-god-53bac6c17e960.jpg",
+                    "likes": "1"
+                }
+            ]
+        },
+        "14d9ed56-09dd-4247-b5b2-add06260a79a": {
+            "albumcover": [
+                {
+                    "id": "129208",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/albumcover/afterlife-53bac73411c0d.jpg",
+                    "likes": "1"
+                }
+            ]
+        },
+        "f12684ec-4fef-4726-a1fe-8fa96a6bb1ce": {
+            "albumcover": [
+                {
+                    "id": "128448",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/albumcover/almost-easy-53b3b72787936.jpg",
+                    "likes": "1"
+                }
+            ]
+        },
+        "ceb758f6-aaa9-37a9-a32e-1c21127394e3": {
+            "albumcover": [
+                {
+                    "id": "128451",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/albumcover/burn-it-down-53b3b7ae7c0da.jpg",
+                    "likes": "1"
+                }
+            ]
+        },
+        "9083fc88-0f05-4a30-b38d-a23e02dbb3d0": {
+            "albumcover": [
+                {
+                    "id": "128453",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/albumcover/welcome-to-the-family-53b3b876a15a9.jpeg",
+                    "likes": "1"
+                }
+            ]
+        },
+        "93ed6b5b-818a-4755-8767-de707c9619b8": {
+            "albumcover": [
+                {
+                    "id": "231762",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/albumcover/live-at-the-grammy-museum-5a2eb8f73efad.jpg",
+                    "likes": "0"
+                }
+            ]
+        },
+        "9c564498-48e5-4ee5-bb3a-dbc003cb36e2": {
+            "albumcover": [
+                {
+                    "id": "248157",
+                    "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/albumcover/black-reign-5ba7d9ae1b7ad.jpg",
+                    "likes": "0"
+                }
+            ]
+        }
+    },
+    "hdmusiclogo": [
+        {
+            "id": "102865",
+            "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/hdmusiclogo/avenged-sevenfold-526fc8c4162a1.png",
+            "likes": "2"
+        },
+        {
+            "id": "49644",
+            "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/hdmusiclogo/avenged-sevenfold-503fcebece042.png",
+            "likes": "2"
+        },
+        {
+            "id": "252774",
+            "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/hdmusiclogo/avenged-sevenfold-5c0de54aee1e1.png",
+            "likes": "1"
+        },
+        {
+            "id": "252775",
+            "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/hdmusiclogo/avenged-sevenfold-5c0de55415caf.png",
+            "likes": "1"
+        },
+        {
+            "id": "249963",
+            "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/hdmusiclogo/avenged-sevenfold-5bcd06e699335.png",
+            "likes": "1"
+        },
+        {
+            "id": "125845",
+            "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/hdmusiclogo/avenged-sevenfold-538ce566b1184.png",
+            "likes": "1"
+        },
+        {
+            "id": "142153",
+            "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/hdmusiclogo/avenged-sevenfold-54752ea02da53.png",
+            "likes": "0"
+        },
+        {
+            "id": "125844",
+            "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/hdmusiclogo/avenged-sevenfold-538ce566a8f0a.png",
+            "likes": "0"
+        },
+        {
+            "id": "125888",
+            "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/hdmusiclogo/avenged-sevenfold-538dcd706ac32.png",
+            "likes": "0"
+        },
+        {
+            "id": "102871",
+            "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/hdmusiclogo/avenged-sevenfold-526fd948c757d.png",
+            "likes": "0"
+        },
+        {
+            "id": "49645",
+            "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/hdmusiclogo/avenged-sevenfold-503fcebecf17e.png",
+            "likes": "0"
+        }
+    ],
+    "artistthumb": [
+        {
+            "id": "95995",
+            "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/artistthumb/avenged-sevenfold-521f7ed77cf4f.jpg",
+            "likes": "2"
+        },
+        {
+            "id": "249978",
+            "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/artistthumb/avenged-sevenfold-5bcd121f3fda0.jpg",
+            "likes": "1"
+        },
+        {
+            "id": "64042",
+            "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/artistthumb/avenged-sevenfold-50c4d9279d6e9.jpg",
+            "likes": "0"
+        },
+        {
+            "id": "31109",
+            "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/artistthumb/avenged-sevenfold-4fb2b533bc73a.jpg",
+            "likes": "0"
+        }
+    ],
+    "artistbackground": [
+        {
+            "id": "64048",
+            "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/artistbackground/avenged-sevenfold-50c4dc653f004.jpg",
+            "likes": "1"
+        },
+        {
+            "id": "3027",
+            "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/artistbackground/avenged-sevenfold-4ddd7889a0fcf.jpg",
+            "likes": "1"
+        },
+        {
+            "id": "80600",
+            "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/artistbackground/avenged-sevenfold-517bf40c1fb22.jpg",
+            "likes": "1"
+        },
+        {
+            "id": "105700",
+            "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/artistbackground/avenged-sevenfold-529652bade8a4.jpg",
+            "likes": "1"
+        },
+        {
+            "id": "95993",
+            "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/artistbackground/avenged-sevenfold-521f7b1318390.jpg",
+            "likes": "1"
+        },
+        {
+            "id": "64046",
+            "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/artistbackground/avenged-sevenfold-50c4db9a2c6e2.jpg",
+            "likes": "0"
+        },
+        {
+            "id": "76946",
+            "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/artistbackground/avenged-sevenfold-51544ff4401ab.jpg",
+            "likes": "0"
+        },
+        {
+            "id": "105695",
+            "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/artistbackground/avenged-sevenfold-52964c30e0486.jpg",
+            "likes": "0"
+        },
+        {
+            "id": "105697",
+            "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/artistbackground/avenged-sevenfold-52964cdfa6282.jpg",
+            "likes": "0"
+        },
+        {
+            "id": "105698",
+            "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/artistbackground/avenged-sevenfold-52964d9c79f26.jpg",
+            "likes": "0"
+        },
+        {
+            "id": "105702",
+            "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/artistbackground/avenged-sevenfold-529653ef8cef7.jpg",
+            "likes": "0"
+        },
+        {
+            "id": "95994",
+            "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/artistbackground/avenged-sevenfold-521f7e4c48ad3.jpg",
+            "likes": "0"
+        }
+    ],
+    "musiclogo": [
+        {
+            "id": "5712",
+            "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/musiclogo/avenged-sevenfold-4dfc8aee78b49.png",
+            "likes": "0"
+        },
+        {
+            "id": "41835",
+            "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/musiclogo/avenged-sevenfold-4ffc75f3a7e54.png",
+            "likes": "0"
+        },
+        {
+            "id": "41836",
+            "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/musiclogo/avenged-sevenfold-4ffc75f3a8473.png",
+            "likes": "0"
+        }
+    ],
+    "musicbanner": [
+        {
+            "id": "52630",
+            "url": "https://assets.fanart.tv/fanart/music/24e1b53c-3085-4581-8472-0b0088d2508c/musicbanner/avenged-sevenfold-505b2346a559d.jpg",
+            "likes": "0"
+        }
+    ]
 }

--- a/fanart/tests/response/tv_239761.json
+++ b/fanart/tests/response/tv_239761.json
@@ -1,196 +1,256 @@
 {
-    "Wilfred (US)": {
-        "hdclearart": [
-            {
-                "url": "http://assets.fanart.tv/fanart/tv/239761/hdclearart/wilfred-us-505f94ed0ba13.png",
-                "lang": "en",
-                "id": "21112",
-                "likes": "1"
-            },
-            {
-                "url": "http://assets.fanart.tv/fanart/tv/239761/hdclearart/wilfred-us-52403264aa3ec.png",
-                "lang": "he",
-                "id": "33751",
-                "likes": "1"
-            }
-        ],
-        "seasonthumb": [
-            {
-                "url": "http://assets.fanart.tv/fanart/tv/239761/seasonthumb/wilfred-us-52403782bab55.jpg",
-                "lang": "he",
-                "id": "33752",
-                "season": "1",
-                "likes": "1"
-            },
-            {
-                "url": "http://assets.fanart.tv/fanart/tv/239761/seasonthumb/wilfred-us-5240379335232.jpg",
-                "lang": "he",
-                "id": "33753",
-                "season": "2",
-                "likes": "1"
-            },
-            {
-                "url": "http://assets.fanart.tv/fanart/tv/239761/seasonthumb/wilfred-us-524037bc83c7d.jpg",
-                "lang": "he",
-                "id": "33754",
-                "season": "3",
-                "likes": "1"
-            },
-            {
-                "url": "http://assets.fanart.tv/fanart/tv/239761/seasonthumb/wilfred-us-501bb0a8e60f9.jpg",
-                "lang": "en",
-                "id": "19586",
-                "season": "1",
-                "likes": "0"
-            },
-            {
-                "url": "http://assets.fanart.tv/fanart/tv/239761/seasonthumb/wilfred-us-501bb0b4bf229.jpg",
-                "lang": "en",
-                "id": "19587",
-                "season": "2",
-                "likes": "0"
-            },
-            {
-                "url": "http://assets.fanart.tv/fanart/tv/239761/seasonthumb/wilfred-us-501bb144e6a46.jpg",
-                "lang": "en",
-                "id": "19588",
-                "season": "0",
-                "likes": "0"
-            },
-            {
-                "url": "http://assets.fanart.tv/fanart/tv/239761/seasonthumb/wilfred-us-51c953105ef77.jpg",
-                "lang": "en",
-                "id": "30309",
-                "season": "3",
-                "likes": "0"
-            }
-        ],
-        "tvbanner": [
-            {
-                "url": "http://assets.fanart.tv/fanart/tv/239761/tvbanner/wilfred-us-52403a7185070.jpg",
-                "lang": "he",
-                "id": "33755",
-                "likes": "1"
-            },
-            {
-                "url": "http://assets.fanart.tv/fanart/tv/239761/tvbanner/wilfred-us-5265193db51f7.jpg",
-                "lang": "en",
-                "id": "34716",
-                "likes": "0"
-            }
-        ],
-        "thetvdb_id": "239761",
-        "clearlogo": [
-            {
-                "url": "http://assets.fanart.tv/fanart/tv/239761/clearlogo/wilfred-us-4e04b6495dfd3.png",
-                "lang": "en",
-                "id": "11977",
-                "likes": "2"
-            },
-            {
-                "url": "http://assets.fanart.tv/fanart/tv/239761/clearlogo/wilfred-us-517ac36e39f67.png",
-                "lang": "en",
-                "id": "28249",
-                "likes": "1"
-            },
-            {
-                "url": "http://assets.fanart.tv/fanart/tv/239761/clearlogo/wilfred-us-51f557082cfde.png",
-                "lang": "en",
-                "id": "31817",
-                "likes": "0"
-            }
-        ],
-        "tvposter": [
-            {
-                "url": "http://assets.fanart.tv/fanart/tv/239761/tvposter/wilfred-us-525d893230d7c.jpg",
-                "lang": "he",
-                "id": "34584",
-                "likes": "1"
-            }
-        ],
-        "showbackground": [
-            {
-                "url": "http://assets.fanart.tv/fanart/tv/239761/showbackground/wilfred-us-5034dbd49115e.jpg",
-                "lang": "en",
-                "id": "19965",
-                "season": "all",
-                "likes": "0"
-            },
-            {
-                "url": "http://assets.fanart.tv/fanart/tv/239761/showbackground/wilfred-us-50b0c92db6973.jpg",
-                "lang": "en",
-                "id": "23166",
-                "season": "all",
-                "likes": "0"
-            },
-            {
-                "url": "http://assets.fanart.tv/fanart/tv/239761/showbackground/wilfred-us-50b0c92dbb46b.jpg",
-                "lang": "en",
-                "id": "23167",
-                "season": "all",
-                "likes": "0"
-            },
-            {
-                "url": "http://assets.fanart.tv/fanart/tv/239761/showbackground/wilfred-us-50b0c92dbb9d1.jpg",
-                "lang": "en",
-                "id": "23168",
-                "season": "all",
-                "likes": "0"
-            }
-        ],
-        "tvthumb": [
-            {
-                "url": "http://assets.fanart.tv/fanart/tv/239761/tvthumb/wilfred-us-501cf526174fe.jpg",
-                "lang": "en",
-                "id": "19596",
-                "likes": "1"
-            },
-            {
-                "url": "http://assets.fanart.tv/fanart/tv/239761/tvthumb/wilfred-us-51bfb4a105904.jpg",
-                "lang": "en",
-                "id": "30060",
-                "likes": "0"
-            }
-        ],
-        "clearart": [
-            {
-                "url": "http://assets.fanart.tv/fanart/tv/239761/clearart/wilfred-us-4e05f10e87711.png",
-                "lang": "en",
-                "id": "11987",
-                "likes": "2"
-            },
-            {
-                "url": "http://assets.fanart.tv/fanart/tv/239761/clearart/wilfred-us-4e2f151d5ed62.png",
-                "lang": "en",
-                "id": "12470",
-                "likes": "1"
-            }
-        ],
-        "hdtvlogo": [
-            {
-                "url": "http://assets.fanart.tv/fanart/tv/239761/hdtvlogo/wilfred-us-505f373be58e6.png",
-                "lang": "en",
-                "id": "21101",
-                "likes": "1"
-            },
-            {
-                "url": "http://assets.fanart.tv/fanart/tv/239761/hdtvlogo/wilfred-us-517ac360def17.png",
-                "lang": "en",
-                "id": "28248",
-                "likes": "1"
-            },
-            {
-                "url": "http://assets.fanart.tv/fanart/tv/239761/hdtvlogo/wilfred-us-52402df7ed945.png",
-                "lang": "he",
-                "id": "33750",
-                "likes": "1"
-            },
-            {
-                "url": "http://assets.fanart.tv/fanart/tv/239761/hdtvlogo/wilfred-us-51f556fb4abd3.png",
-                "lang": "en",
-                "id": "31816",
-                "likes": "0"
-            }
-        ]
-    }
+    "name": "Wilfred (US)",
+    "thetvdb_id": "239761",
+    "clearlogo": [
+        {
+            "id": "11977",
+            "url": "https://assets.fanart.tv/fanart/tv/239761/clearlogo/wilfred-us-4e04b6495dfd3.png",
+            "lang": "en",
+            "likes": "2"
+        },
+        {
+            "id": "28249",
+            "url": "https://assets.fanart.tv/fanart/tv/239761/clearlogo/wilfred-us-517ac36e39f67.png",
+            "lang": "en",
+            "likes": "1"
+        },
+        {
+            "id": "31817",
+            "url": "https://assets.fanart.tv/fanart/tv/239761/clearlogo/wilfred-us-51f557082cfde.png",
+            "lang": "en",
+            "likes": "0"
+        }
+    ],
+    "clearart": [
+        {
+            "id": "11987",
+            "url": "https://assets.fanart.tv/fanart/tv/239761/clearart/wilfred-us-4e05f10e87711.png",
+            "lang": "en",
+            "likes": "2"
+        },
+        {
+            "id": "12470",
+            "url": "https://assets.fanart.tv/fanart/tv/239761/clearart/wilfred-us-4e2f151d5ed62.png",
+            "lang": "en",
+            "likes": "1"
+        }
+    ],
+    "hdtvlogo": [
+        {
+            "id": "21101",
+            "url": "https://assets.fanart.tv/fanart/tv/239761/hdtvlogo/wilfred-us-505f373be58e6.png",
+            "lang": "en",
+            "likes": "2"
+        },
+        {
+            "id": "28248",
+            "url": "https://assets.fanart.tv/fanart/tv/239761/hdtvlogo/wilfred-us-517ac360def17.png",
+            "lang": "en",
+            "likes": "2"
+        },
+        {
+            "id": "33750",
+            "url": "https://assets.fanart.tv/fanart/tv/239761/hdtvlogo/wilfred-us-52402df7ed945.png",
+            "lang": "he",
+            "likes": "1"
+        },
+        {
+            "id": "42207",
+            "url": "https://assets.fanart.tv/fanart/tv/239761/hdtvlogo/wilfred-us-53d12425b2d8c.png",
+            "lang": "ru",
+            "likes": "1"
+        },
+        {
+            "id": "31816",
+            "url": "https://assets.fanart.tv/fanart/tv/239761/hdtvlogo/wilfred-us-51f556fb4abd3.png",
+            "lang": "en",
+            "likes": "0"
+        }
+    ],
+    "tvthumb": [
+        {
+            "id": "19596",
+            "url": "https://assets.fanart.tv/fanart/tv/239761/tvthumb/wilfred-us-501cf526174fe.jpg",
+            "lang": "en",
+            "likes": "1"
+        },
+        {
+            "id": "30060",
+            "url": "https://assets.fanart.tv/fanart/tv/239761/tvthumb/wilfred-us-51bfb4a105904.jpg",
+            "lang": "en",
+            "likes": "1"
+        }
+    ],
+    "hdclearart": [
+        {
+            "id": "21112",
+            "url": "https://assets.fanart.tv/fanart/tv/239761/hdclearart/wilfred-us-505f94ed0ba13.png",
+            "lang": "en",
+            "likes": "1"
+        },
+        {
+            "id": "33751",
+            "url": "https://assets.fanart.tv/fanart/tv/239761/hdclearart/wilfred-us-52403264aa3ec.png",
+            "lang": "he",
+            "likes": "1"
+        }
+    ],
+    "seasonthumb": [
+        {
+            "id": "33752",
+            "url": "https://assets.fanart.tv/fanart/tv/239761/seasonthumb/wilfred-us-52403782bab55.jpg",
+            "lang": "he",
+            "likes": "1",
+            "season": "1"
+        },
+        {
+            "id": "33753",
+            "url": "https://assets.fanart.tv/fanart/tv/239761/seasonthumb/wilfred-us-5240379335232.jpg",
+            "lang": "he",
+            "likes": "1",
+            "season": "2"
+        },
+        {
+            "id": "33754",
+            "url": "https://assets.fanart.tv/fanart/tv/239761/seasonthumb/wilfred-us-524037bc83c7d.jpg",
+            "lang": "he",
+            "likes": "1",
+            "season": "3"
+        },
+        {
+            "id": "19586",
+            "url": "https://assets.fanart.tv/fanart/tv/239761/seasonthumb/wilfred-us-501bb0a8e60f9.jpg",
+            "lang": "en",
+            "likes": "0",
+            "season": "1"
+        },
+        {
+            "id": "19587",
+            "url": "https://assets.fanart.tv/fanart/tv/239761/seasonthumb/wilfred-us-501bb0b4bf229.jpg",
+            "lang": "en",
+            "likes": "0",
+            "season": "2"
+        },
+        {
+            "id": "19588",
+            "url": "https://assets.fanart.tv/fanart/tv/239761/seasonthumb/wilfred-us-501bb144e6a46.jpg",
+            "lang": "en",
+            "likes": "0",
+            "season": "0"
+        },
+        {
+            "id": "30309",
+            "url": "https://assets.fanart.tv/fanart/tv/239761/seasonthumb/wilfred-us-51c953105ef77.jpg",
+            "lang": "en",
+            "likes": "0",
+            "season": "3"
+        }
+    ],
+    "tvbanner": [
+        {
+            "id": "33755",
+            "url": "https://assets.fanart.tv/fanart/tv/239761/tvbanner/wilfred-us-52403a7185070.jpg",
+            "lang": "he",
+            "likes": "1"
+        },
+        {
+            "id": "57138",
+            "url": "https://assets.fanart.tv/fanart/tv/239761/tvbanner/wilfred-us-5607140bac1c6.jpg",
+            "lang": "en",
+            "likes": "1"
+        },
+        {
+            "id": "34716",
+            "url": "https://assets.fanart.tv/fanart/tv/239761/tvbanner/wilfred-us-5265193db51f7.jpg",
+            "lang": "en",
+            "likes": "0"
+        },
+        {
+            "id": "36389",
+            "url": "https://assets.fanart.tv/fanart/tv/239761/tvbanner/wilfred-us-52d578d57cb24.jpg",
+            "lang": "en",
+            "likes": "0"
+        },
+        {
+            "id": "36390",
+            "url": "https://assets.fanart.tv/fanart/tv/239761/tvbanner/wilfred-us-52d578de27a66.jpg",
+            "lang": "en",
+            "likes": "0"
+        },
+        {
+            "id": "41457",
+            "url": "https://assets.fanart.tv/fanart/tv/239761/tvbanner/wilfred-us-53a4da4cd2a21.jpg",
+            "lang": "en",
+            "likes": "0"
+        },
+        {
+            "id": "41458",
+            "url": "https://assets.fanart.tv/fanart/tv/239761/tvbanner/wilfred-us-53a4da6b594e5.jpg",
+            "lang": "en",
+            "likes": "0"
+        },
+        {
+            "id": "41685",
+            "url": "https://assets.fanart.tv/fanart/tv/239761/tvbanner/wilfred-us-53b7db8014425.jpg",
+            "lang": "en",
+            "likes": "0"
+        },
+        {
+            "id": "41686",
+            "url": "https://assets.fanart.tv/fanart/tv/239761/tvbanner/wilfred-us-53b7dbb922332.jpg",
+            "lang": "en",
+            "likes": "0"
+        },
+        {
+            "id": "57139",
+            "url": "https://assets.fanart.tv/fanart/tv/239761/tvbanner/wilfred-us-56071512b14d6.jpg",
+            "lang": "en",
+            "likes": "0"
+        }
+    ],
+    "tvposter": [
+        {
+            "id": "34584",
+            "url": "https://assets.fanart.tv/fanart/tv/239761/tvposter/wilfred-us-525d893230d7c.jpg",
+            "lang": "he",
+            "likes": "1"
+        }
+    ],
+    "showbackground": [
+        {
+            "id": "19965",
+            "url": "https://assets.fanart.tv/fanart/tv/239761/showbackground/wilfred-us-5034dbd49115e.jpg",
+            "lang": "",
+            "likes": "0",
+            "season": "all"
+        },
+        {
+            "id": "23166",
+            "url": "https://assets.fanart.tv/fanart/tv/239761/showbackground/wilfred-us-50b0c92db6973.jpg",
+            "lang": "",
+            "likes": "0",
+            "season": "all"
+        },
+        {
+            "id": "23167",
+            "url": "https://assets.fanart.tv/fanart/tv/239761/showbackground/wilfred-us-50b0c92dbb46b.jpg",
+            "lang": "",
+            "likes": "0",
+            "season": "all"
+        },
+        {
+            "id": "23168",
+            "url": "https://assets.fanart.tv/fanart/tv/239761/showbackground/wilfred-us-50b0c92dbb9d1.jpg",
+            "lang": "",
+            "likes": "0",
+            "season": "all"
+        },
+        {
+            "id": "36386",
+            "url": "https://assets.fanart.tv/fanart/tv/239761/showbackground/wilfred-us-52d53d75d4782.jpg",
+            "lang": "",
+            "likes": "0",
+            "season": "all"
+        }
+    ]
 }

--- a/fanart/tests/response/tv_79349.json
+++ b/fanart/tests/response/tv_79349.json
@@ -1,756 +1,1408 @@
 {
-    "Dexter": {
-        "thetvdb_id": "79349",
-        "hdtvlogo": [
-            {
-                "id": "20959",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/hdtvlogo/dexter-50575994eb118.png",
-                "lang": "en",
-                "likes": "10"
-            },
-            {
-                "id": "20378",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/hdtvlogo/dexter-503fc2f24d9b3.png",
-                "lang": "en",
-                "likes": "5"
-            }
-        ],
-        "hdclearart": [
-            {
-                "id": "23059",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/hdclearart/dexter-50af98e73b0a5.png",
-                "lang": "en",
-                "likes": "8"
-            },
-            {
-                "id": "24313",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/hdclearart/dexter-50eb4363da522.png",
-                "lang": "en",
-                "likes": "5"
-            },
-            {
-                "id": "20560",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/hdclearart/dexter-504775fd50557.png",
-                "lang": "en",
-                "likes": "4"
-            },
-            {
-                "id": "29495",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/hdclearart/dexter-51aa63100548b.png",
-                "lang": "en",
-                "likes": "3"
-            },
-            {
-                "id": "26712",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/hdclearart/dexter-51400b1672938.png",
-                "lang": "en",
-                "likes": "1"
-            },
-            {
-                "id": "29496",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/hdclearart/dexter-51aa724f0a2ab.png",
-                "lang": "en",
-                "likes": "1"
-            },
-            {
-                "id": "29505",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/hdclearart/dexter-51aab23851368.png",
-                "lang": "en",
-                "likes": "1"
-            },
-            {
-                "id": "29594",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/hdclearart/dexter-51afbcdf38d5e.png",
-                "lang": "en",
-                "likes": "1"
-            },
-            {
-                "id": "29595",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/hdclearart/dexter-51afbcdf3ea8e.png",
-                "lang": "en",
-                "likes": "1"
-            }
-        ],
-        "clearlogo": [
-            {
-                "id": "20958",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/clearlogo/dexter-5057573260826.png",
-                "lang": "en",
-                "likes": "6"
-            },
-            {
-                "id": "2114",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/clearlogo/Dexter-79349-2.png",
-                "lang": "en",
-                "likes": "4"
-            },
-            {
-                "id": "14577",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/clearlogo/dexter-4ecdf0c030189.png",
-                "lang": "en",
-                "likes": "3"
-            },
-            {
-                "id": "16685",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/clearlogo/dexter-4f6879db58edf.png",
-                "lang": "ru",
-                "likes": "1"
-            }
-        ],
-        "characterart": [
-            {
-                "id": "16825",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/characterart/dexter-4f76318ae4410.png",
-                "lang": "en",
-                "likes": "5"
-            },
-            {
-                "id": "29497",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/characterart/dexter-51aa726346bcf.png",
-                "lang": "en",
-                "likes": "3"
-            },
-            {
-                "id": "14981",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/characterart/dexter-4eface5cee809.png",
-                "lang": "en",
-                "likes": "1"
-            },
-            {
-                "id": "16996",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/characterart/dexter-4f8189d220d4b.png",
-                "lang": "en",
-                "likes": "1"
-            },
-            {
-                "id": "26713",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/characterart/dexter-51400b26c65de.png",
-                "lang": "en",
-                "likes": "1"
-            },
-            {
-                "id": "29597",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/characterart/dexter-51afbcf6002a7.png",
-                "lang": "en",
-                "likes": "1"
-            },
-            {
-                "id": "29598",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/characterart/dexter-51afbcf6006e6.png",
-                "lang": "en",
-                "likes": "1"
-            },
-            {
-                "id": "29646",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/characterart/dexter-51b0fc45e0dc0.png",
-                "lang": "en",
-                "likes": "1"
-            }
-        ],
-        "clearart": [
-            {
-                "id": "4980",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/clearart/D_79349 (3).png",
-                "lang": "en",
-                "likes": "4"
-            },
-            {
-                "id": "14579",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/clearart/dexter-4ecdf0db2adf1.png",
-                "lang": "en",
-                "likes": "3"
-            },
-            {
-                "id": "16682",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/clearart/dexter-4f68753540f2d.png",
-                "lang": "ru",
-                "likes": "1"
-            },
-            {
-                "id": "4982",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/clearart/D_79349.png",
-                "lang": "en",
-                "likes": "0"
-            },
-            {
-                "id": "4983",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/clearart/D_79349 (1).png",
-                "lang": "en",
-                "likes": "0"
-            },
-            {
-                "id": "4984",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/clearart/D_79349 (0).png",
-                "lang": "en",
-                "likes": "0"
-            },
-            {
-                "id": "14578",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/clearart/dexter-4ecdf0cf3fb38.png",
-                "lang": "en",
-                "likes": "0"
-            },
-            {
-                "id": "17196",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/clearart/dexter-4f8af83f3bde7.png",
-                "lang": "en",
-                "likes": "0"
-            }
-        ],
-        "showbackground": [
-            {
-                "id": "18467",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/showbackground/dexter-4fc683691dea7.jpg",
-                "lang": "en",
-                "likes": "4",
-                "season": "1"
-            },
-            {
-                "id": "18950",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/showbackground/dexter-4fdf608e2df53.jpg",
-                "lang": "en",
-                "likes": "2",
-                "season": "3"
-            },
-            {
-                "id": "18466",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/showbackground/dexter-4fc6830dc2ccc.jpg",
-                "lang": "en",
-                "likes": "1",
-                "season": "4"
-            },
-            {
-                "id": "18468",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/showbackground/dexter-4fc683a5ab451.jpg",
-                "lang": "en",
-                "likes": "1",
-                "season": "6"
-            },
-            {
-                "id": "21524",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/showbackground/dexter-506bdd9c35771.jpg",
-                "lang": "en",
-                "likes": "1",
-                "season": "all"
-            },
-            {
-                "id": "21526",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/showbackground/dexter-506bddc9f04cb.jpg",
-                "lang": "en",
-                "likes": "1",
-                "season": ""
-            },
-            {
-                "id": "21530",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/showbackground/dexter-506bde2654668.jpg",
-                "lang": "en",
-                "likes": "1",
-                "season": "all"
-            },
-            {
-                "id": "24058",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/showbackground/dexter-50def777ea9c8.jpg",
-                "lang": "en",
-                "likes": "1",
-                "season": "all"
-            },
-            {
-                "id": "18515",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/showbackground/dexter-4fc8eab16803c.jpg",
-                "lang": "en",
-                "likes": "0",
-                "season": "all"
-            },
-            {
-                "id": "18947",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/showbackground/dexter-4fdf5e107be0d.jpg",
-                "lang": "en",
-                "likes": "0",
-                "season": "5"
-            },
-            {
-                "id": "18949",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/showbackground/dexter-4fdf601385517.jpg",
-                "lang": "en",
-                "likes": "0",
-                "season": "all"
-            },
-            {
-                "id": "18952",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/showbackground/dexter-4fdf6386ce1c1.jpg",
-                "lang": "en",
-                "likes": "0",
-                "season": "all"
-            },
-            {
-                "id": "21525",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/showbackground/dexter-506bddb3bd3f4.jpg",
-                "lang": "en",
-                "likes": "0",
-                "season": "all"
-            },
-            {
-                "id": "21527",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/showbackground/dexter-506bdddc3f476.jpg",
-                "lang": "en",
-                "likes": "0",
-                "season": "all"
-            },
-            {
-                "id": "21529",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/showbackground/dexter-506bde113406e.jpg",
-                "lang": "en",
-                "likes": "0",
-                "season": "all"
-            },
-            {
-                "id": "24046",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/showbackground/dexter-50de1f84e736f.jpg",
-                "lang": "en",
-                "likes": "0",
-                "season": "all"
-            },
-            {
-                "id": "24048",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/showbackground/dexter-50de1f84e7d57.jpg",
-                "lang": "en",
-                "likes": "0",
-                "season": "all"
-            },
-            {
-                "id": "24049",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/showbackground/dexter-50de21ac3ae25.jpg",
-                "lang": "en",
-                "likes": "0",
-                "season": "all"
-            },
-            {
-                "id": "24054",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/showbackground/dexter-50def777e84d0.jpg",
-                "lang": "en",
-                "likes": "0",
-                "season": "all"
-            },
-            {
-                "id": "24055",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/showbackground/dexter-50def777e8dbc.jpg",
-                "lang": "en",
-                "likes": "0",
-                "season": "all"
-            },
-            {
-                "id": "24056",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/showbackground/dexter-50def777e9762.jpg",
-                "lang": "en",
-                "likes": "0",
-                "season": "all"
-            },
-            {
-                "id": "24986",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/showbackground/dexter-5101fa187c857.jpg",
-                "lang": "en",
-                "likes": "0",
-                "season": "all"
-            }
-        ],
-        "seasonthumb": [
-            {
-                "id": "18986",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/seasonthumb/dexter-4fe21b7708ebe.jpg",
-                "lang": "en",
-                "likes": "3",
-                "season": "6"
-            },
-            {
-                "id": "5002",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/seasonthumb/Dexter (6).jpg",
-                "lang": "en",
-                "likes": "1",
-                "season": "3"
-            },
-            {
-                "id": "5003",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/seasonthumb/Dexter (5).jpg",
-                "lang": "en",
-                "likes": "1",
-                "season": "1"
-            },
-            {
-                "id": "17802",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/seasonthumb/dexter-4fa981a7251d7.jpg",
-                "lang": "en",
-                "likes": "1",
-                "season": "5"
-            },
-            {
-                "id": "17823",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/seasonthumb/dexter-4faab0bccbfb6.jpg",
-                "lang": "en",
-                "likes": "1",
-                "season": "6"
-            },
-            {
-                "id": "18980",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/seasonthumb/dexter-4fe21a6955116.jpg",
-                "lang": "en",
-                "likes": "1",
-                "season": "1"
-            },
-            {
-                "id": "18982",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/seasonthumb/dexter-4fe21b0767edb.jpg",
-                "lang": "en",
-                "likes": "1",
-                "season": "2"
-            },
-            {
-                "id": "18983",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/seasonthumb/dexter-4fe21b292d661.jpg",
-                "lang": "en",
-                "likes": "1",
-                "season": "3"
-            },
-            {
-                "id": "18984",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/seasonthumb/dexter-4fe21b42d983d.jpg",
-                "lang": "en",
-                "likes": "1",
-                "season": "4"
-            },
-            {
-                "id": "18985",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/seasonthumb/dexter-4fe21b5847d7b.jpg",
-                "lang": "en",
-                "likes": "1",
-                "season": "5"
-            },
-            {
-                "id": "21883",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/seasonthumb/dexter-5071800d37e80.jpg",
-                "lang": "en",
-                "likes": "1",
-                "season": "7"
-            },
-            {
-                "id": "4989",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/seasonthumb/Dexter (9).jpg",
-                "lang": "en",
-                "likes": "0",
-                "season": "all"
-            },
-            {
-                "id": "4990",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/seasonthumb/Dexter (19).jpg",
-                "lang": "en",
-                "likes": "0",
-                "season": "4"
-            },
-            {
-                "id": "4991",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/seasonthumb/Dexter (18).jpg",
-                "lang": "en",
-                "likes": "0",
-                "season": "4"
-            },
-            {
-                "id": "4992",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/seasonthumb/Dexter (17).jpg",
-                "lang": "en",
-                "likes": "0",
-                "season": "3"
-            },
-            {
-                "id": "4993",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/seasonthumb/Dexter (16).jpg",
-                "lang": "en",
-                "likes": "0",
-                "season": "2"
-            },
-            {
-                "id": "4994",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/seasonthumb/Dexter (15).jpg",
-                "lang": "en",
-                "likes": "0",
-                "season": "1"
-            },
-            {
-                "id": "4995",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/seasonthumb/Dexter (14).jpg",
-                "lang": "en",
-                "likes": "0",
-                "season": "all"
-            },
-            {
-                "id": "4996",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/seasonthumb/Dexter (13).jpg",
-                "lang": "en",
-                "likes": "0",
-                "season": "4"
-            },
-            {
-                "id": "4997",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/seasonthumb/Dexter (12).jpg",
-                "lang": "en",
-                "likes": "0",
-                "season": "3"
-            },
-            {
-                "id": "4998",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/seasonthumb/Dexter (11).jpg",
-                "lang": "en",
-                "likes": "0",
-                "season": "2"
-            },
-            {
-                "id": "4999",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/seasonthumb/Dexter (10).jpg",
-                "lang": "en",
-                "likes": "0",
-                "season": "1"
-            },
-            {
-                "id": "5000",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/seasonthumb/Dexter (8).jpg",
-                "lang": "en",
-                "likes": "0",
-                "season": "2"
-            },
-            {
-                "id": "5001",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/seasonthumb/Dexter (7).jpg",
-                "lang": "en",
-                "likes": "0",
-                "season": "4"
-            },
-            {
-                "id": "5004",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/seasonthumb/Dexter.jpg",
-                "lang": "en",
-                "likes": "0",
-                "season": "all"
-            },
-            {
-                "id": "5005",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/seasonthumb/Dexter (4).jpg",
-                "lang": "en",
-                "likes": "0",
-                "season": "5"
-            },
-            {
-                "id": "5006",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/seasonthumb/Dexter (3).jpg",
-                "lang": "en",
-                "likes": "0",
-                "season": "4"
-            },
-            {
-                "id": "5007",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/seasonthumb/Dexter (2).jpg",
-                "lang": "en",
-                "likes": "0",
-                "season": "3"
-            },
-            {
-                "id": "5008",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/seasonthumb/Dexter (1).jpg",
-                "lang": "en",
-                "likes": "0",
-                "season": "2"
-            },
-            {
-                "id": "5009",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/seasonthumb/Dexter (0).jpg",
-                "lang": "en",
-                "likes": "0",
-                "season": "1"
-            },
-            {
-                "id": "17803",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/seasonthumb/dexter-4fa981a7258fb.jpg",
-                "lang": "en",
-                "likes": "0",
-                "season": "5"
-            },
-            {
-                "id": "17804",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/seasonthumb/dexter-4fa981a725c14.jpg",
-                "lang": "en",
-                "likes": "0",
-                "season": "5"
-            },
-            {
-                "id": "17805",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/seasonthumb/dexter-4fa981c6607e4.jpg",
-                "lang": "en",
-                "likes": "0",
-                "season": "0"
-            },
-            {
-                "id": "17807",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/seasonthumb/dexter-4fa98ac2b811d.jpg",
-                "lang": "en",
-                "likes": "0",
-                "season": "6"
-            },
-            {
-                "id": "17808",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/seasonthumb/dexter-4fa98ac2b87ab.jpg",
-                "lang": "en",
-                "likes": "0",
-                "season": "6"
-            },
-            {
-                "id": "17810",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/seasonthumb/dexter-4fa994697afa3.jpg",
-                "lang": "en",
-                "likes": "0",
-                "season": "6"
-            },
-            {
-                "id": "18514",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/seasonthumb/dexter-4fc8e9fa79bf8.jpg",
-                "lang": "en",
-                "likes": "0",
-                "season": "7"
-            },
-            {
-                "id": "31022",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/seasonthumb/dexter-51dc720661cb7.jpg",
-                "lang": "en",
-                "likes": "0",
-                "season": "8"
-            },
-            {
-                "id": "31023",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/seasonthumb/dexter-51dc72a19a0bb.jpg",
-                "lang": "en",
-                "likes": "0",
-                "season": "8"
-            }
-        ],
-        "tvthumb": [
-            {
-                "id": "5012",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/tvthumb/D_79349 (10).jpg",
-                "lang": "en",
-                "likes": "2"
-            },
-            {
-                "id": "5023",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/tvthumb/D_79349 (0).jpg",
-                "lang": "en",
-                "likes": "2"
-            },
-            {
-                "id": "14580",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/tvthumb/dexter-4ecdf5027a53c.jpg",
-                "lang": "en",
-                "likes": "2"
-            },
-            {
-                "id": "5013",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/tvthumb/D_79349 (9).jpg",
-                "lang": "en",
-                "likes": "1"
-            },
-            {
-                "id": "5016",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/tvthumb/D_79349 (6).jpg",
-                "lang": "en",
-                "likes": "1"
-            },
-            {
-                "id": "5020",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/tvthumb/D_79349 (2).jpg",
-                "lang": "en",
-                "likes": "1"
-            },
-            {
-                "id": "29341",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/tvthumb/dexter-51a338d376b4a.jpg",
-                "lang": "de",
-                "likes": "1"
-            },
-            {
-                "id": "31722",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/tvthumb/dexter-51f27112a2a89.jpg",
-                "lang": "en",
-                "likes": "1"
-            },
-            {
-                "id": "5010",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/tvthumb/D_79349 (12).jpg",
-                "lang": "en",
-                "likes": "0"
-            },
-            {
-                "id": "5011",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/tvthumb/D_79349 (11).jpg",
-                "lang": "en",
-                "likes": "0"
-            },
-            {
-                "id": "5014",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/tvthumb/D_79349 (8).jpg",
-                "lang": "en",
-                "likes": "0"
-            },
-            {
-                "id": "5015",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/tvthumb/D_79349 (7).jpg",
-                "lang": "en",
-                "likes": "0"
-            },
-            {
-                "id": "5017",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/tvthumb/D_79349 (5).jpg",
-                "lang": "en",
-                "likes": "0"
-            },
-            {
-                "id": "5018",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/tvthumb/D_79349 (4).jpg",
-                "lang": "en",
-                "likes": "0"
-            },
-            {
-                "id": "5019",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/tvthumb/D_79349 (3).jpg",
-                "lang": "en",
-                "likes": "0"
-            },
-            {
-                "id": "5021",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/tvthumb/D_79349.jpg",
-                "lang": "en",
-                "likes": "0"
-            },
-            {
-                "id": "5022",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/tvthumb/D_79349 (1).jpg",
-                "lang": "en",
-                "likes": "0"
-            },
-            {
-                "id": "14277",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/tvthumb/dexter-4ead4375923fd.jpg",
-                "lang": "en",
-                "likes": "0"
-            }
-        ],
-        "tvbanner": [
-            {
-                "id": "30062",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/tvbanner/dexter-51bfc857c84fd.jpg",
-                "lang": "en",
-                "likes": "1"
-            },
-            {
-                "id": "30063",
-                "url": "http://assets.fanart.tv/fanart/tv/79349/tvbanner/dexter-51bfc89667267.jpg",
-                "lang": "en",
-                "likes": "1"
-            }
-        ]
-    }
+    "name": "Dexter",
+    "thetvdb_id": "79349",
+    "hdtvlogo": [
+        {
+            "id": "20959",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/hdtvlogo/dexter-50575994eb118.png",
+            "lang": "en",
+            "likes": "15"
+        },
+        {
+            "id": "20378",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/hdtvlogo/dexter-503fc2f24d9b3.png",
+            "lang": "en",
+            "likes": "9"
+        },
+        {
+            "id": "56928",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/hdtvlogo/dexter-560024323ccde.png",
+            "lang": "it",
+            "likes": "2"
+        },
+        {
+            "id": "33255",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/hdtvlogo/dexter-522612708ad8c.png",
+            "lang": "he",
+            "likes": "1"
+        }
+    ],
+    "hdclearart": [
+        {
+            "id": "23059",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/hdclearart/dexter-50af98e73b0a5.png",
+            "lang": "en",
+            "likes": "12"
+        },
+        {
+            "id": "24313",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/hdclearart/dexter-50eb4363da522.png",
+            "lang": "en",
+            "likes": "5"
+        },
+        {
+            "id": "20560",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/hdclearart/dexter-504775fd50557.png",
+            "lang": "en",
+            "likes": "4"
+        },
+        {
+            "id": "29495",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/hdclearart/dexter-51aa63100548b.png",
+            "lang": "en",
+            "likes": "3"
+        },
+        {
+            "id": "26712",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/hdclearart/dexter-51400b1672938.png",
+            "lang": "en",
+            "likes": "2"
+        },
+        {
+            "id": "29496",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/hdclearart/dexter-51aa724f0a2ab.png",
+            "lang": "en",
+            "likes": "1"
+        },
+        {
+            "id": "29505",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/hdclearart/dexter-51aab23851368.png",
+            "lang": "en",
+            "likes": "1"
+        },
+        {
+            "id": "29594",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/hdclearart/dexter-51afbcdf38d5e.png",
+            "lang": "en",
+            "likes": "1"
+        },
+        {
+            "id": "29595",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/hdclearart/dexter-51afbcdf3ea8e.png",
+            "lang": "en",
+            "likes": "1"
+        },
+        {
+            "id": "33257",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/hdclearart/dexter-52261505049ff.png",
+            "lang": "he",
+            "likes": "1"
+        }
+    ],
+    "seasonposter": [
+        {
+            "id": "39258",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonposter/dexter-5352d0ce4114d.jpg",
+            "lang": "en",
+            "likes": "6",
+            "season": "1"
+        },
+        {
+            "id": "39259",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonposter/dexter-5352d0d949dec.jpg",
+            "lang": "en",
+            "likes": "6",
+            "season": "2"
+        },
+        {
+            "id": "39260",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonposter/dexter-5352d0e277220.jpg",
+            "lang": "en",
+            "likes": "6",
+            "season": "3"
+        },
+        {
+            "id": "39261",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonposter/dexter-5352d0ed6b9e7.jpg",
+            "lang": "en",
+            "likes": "6",
+            "season": "4"
+        },
+        {
+            "id": "39262",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonposter/dexter-5352d0f6ccb3f.jpg",
+            "lang": "en",
+            "likes": "6",
+            "season": "5"
+        },
+        {
+            "id": "39263",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonposter/dexter-5352d100194e2.jpg",
+            "lang": "en",
+            "likes": "6",
+            "season": "6"
+        },
+        {
+            "id": "39264",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonposter/dexter-5352d10a3f9c6.jpg",
+            "lang": "en",
+            "likes": "6",
+            "season": "7"
+        },
+        {
+            "id": "39265",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonposter/dexter-5352d1140a2c1.jpg",
+            "lang": "en",
+            "likes": "6",
+            "season": "8"
+        },
+        {
+            "id": "80646",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonposter/dexter-5a1c37c1831f7.jpg",
+            "lang": "es",
+            "likes": "2",
+            "season": "2"
+        },
+        {
+            "id": "80679",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonposter/dexter-5a1def03bbde1.jpg",
+            "lang": "es",
+            "likes": "2",
+            "season": "4"
+        },
+        {
+            "id": "80680",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonposter/dexter-5a1def1c0a3d6.jpg",
+            "lang": "es",
+            "likes": "2",
+            "season": "5"
+        },
+        {
+            "id": "39026",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonposter/dexter-53503b3a0f996.jpg",
+            "lang": "en",
+            "likes": "2",
+            "season": "1"
+        },
+        {
+            "id": "39027",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonposter/dexter-53503b5eb3b4f.jpg",
+            "lang": "en",
+            "likes": "2",
+            "season": "2"
+        },
+        {
+            "id": "83080",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonposter/dexter-5a9c424eded47.jpg",
+            "lang": "en",
+            "likes": "2",
+            "season": "0"
+        },
+        {
+            "id": "38914",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonposter/dexter-534cd8c694015.jpg",
+            "lang": "en",
+            "likes": "1",
+            "season": "1"
+        },
+        {
+            "id": "38915",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonposter/dexter-534cd8fdc2efc.jpg",
+            "lang": "en",
+            "likes": "1",
+            "season": "2"
+        },
+        {
+            "id": "38916",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonposter/dexter-534cd93a7e5f5.jpg",
+            "lang": "en",
+            "likes": "1",
+            "season": "3"
+        },
+        {
+            "id": "80645",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonposter/dexter-5a1c37adb9f0c.jpg",
+            "lang": "es",
+            "likes": "1",
+            "season": "1"
+        },
+        {
+            "id": "38917",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonposter/dexter-534cd96d73a88.jpg",
+            "lang": "en",
+            "likes": "1",
+            "season": "4"
+        },
+        {
+            "id": "38918",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonposter/dexter-534cd9841a7f0.jpg",
+            "lang": "en",
+            "likes": "1",
+            "season": "5"
+        },
+        {
+            "id": "38919",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonposter/dexter-534cd9a780844.jpg",
+            "lang": "en",
+            "likes": "1",
+            "season": "6"
+        },
+        {
+            "id": "38920",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonposter/dexter-534cd9ba9b394.jpg",
+            "lang": "en",
+            "likes": "1",
+            "season": "7"
+        },
+        {
+            "id": "38921",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonposter/dexter-534cd9d1b434d.jpg",
+            "lang": "en",
+            "likes": "1",
+            "season": "8"
+        },
+        {
+            "id": "80677",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonposter/dexter-5a1deeee90cda.jpg",
+            "lang": "es",
+            "likes": "1",
+            "season": "3"
+        },
+        {
+            "id": "80681",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonposter/dexter-5a1def2e96eb2.jpg",
+            "lang": "es",
+            "likes": "1",
+            "season": "6"
+        },
+        {
+            "id": "67422",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonposter/dexter-582458e8cf1a1.jpg",
+            "lang": "it",
+            "likes": "0",
+            "season": "1"
+        },
+        {
+            "id": "67423",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonposter/dexter-5824590749728.jpg",
+            "lang": "it",
+            "likes": "0",
+            "season": "2"
+        },
+        {
+            "id": "67424",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonposter/dexter-5824592038b2d.jpg",
+            "lang": "it",
+            "likes": "0",
+            "season": "3"
+        },
+        {
+            "id": "67425",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonposter/dexter-5824593db6e54.jpg",
+            "lang": "it",
+            "likes": "0",
+            "season": "4"
+        },
+        {
+            "id": "67426",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonposter/dexter-582459575f848.jpg",
+            "lang": "it",
+            "likes": "0",
+            "season": "5"
+        },
+        {
+            "id": "67427",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonposter/dexter-5824597422014.jpg",
+            "lang": "it",
+            "likes": "0",
+            "season": "6"
+        },
+        {
+            "id": "67428",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonposter/dexter-582459a109f95.jpg",
+            "lang": "it",
+            "likes": "0",
+            "season": "7"
+        },
+        {
+            "id": "67430",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonposter/dexter-582459b84b922.jpg",
+            "lang": "it",
+            "likes": "0",
+            "season": "8"
+        },
+        {
+            "id": "39015",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonposter/dexter-53502befabd2c.jpg",
+            "lang": "en",
+            "likes": "0",
+            "season": "1"
+        },
+        {
+            "id": "39016",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonposter/dexter-53502c0f845b5.jpg",
+            "lang": "en",
+            "likes": "0",
+            "season": "2"
+        },
+        {
+            "id": "39017",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonposter/dexter-53502c2757c78.jpg",
+            "lang": "en",
+            "likes": "0",
+            "season": "3"
+        },
+        {
+            "id": "39018",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonposter/dexter-53502e082e6df.jpg",
+            "lang": "en",
+            "likes": "0",
+            "season": "4"
+        },
+        {
+            "id": "39019",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonposter/dexter-53502e4d5a5ee.jpg",
+            "lang": "en",
+            "likes": "0",
+            "season": "5"
+        },
+        {
+            "id": "39020",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonposter/dexter-53502e7fe0fc4.jpg",
+            "lang": "en",
+            "likes": "0",
+            "season": "6"
+        },
+        {
+            "id": "39024",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonposter/dexter-53502f33bca2f.jpg",
+            "lang": "en",
+            "likes": "0",
+            "season": "7"
+        }
+    ],
+    "characterart": [
+        {
+            "id": "16825",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/characterart/dexter-4f76318ae4410.png",
+            "lang": "en",
+            "likes": "6"
+        },
+        {
+            "id": "29497",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/characterart/dexter-51aa726346bcf.png",
+            "lang": "en",
+            "likes": "4"
+        },
+        {
+            "id": "14981",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/characterart/dexter-4eface5cee809.png",
+            "lang": "en",
+            "likes": "2"
+        },
+        {
+            "id": "29598",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/characterart/dexter-51afbcf6006e6.png",
+            "lang": "en",
+            "likes": "2"
+        },
+        {
+            "id": "26713",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/characterart/dexter-51400b26c65de.png",
+            "lang": "en",
+            "likes": "1"
+        },
+        {
+            "id": "16996",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/characterart/dexter-4f8189d220d4b.png",
+            "lang": "en",
+            "likes": "1"
+        },
+        {
+            "id": "29597",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/characterart/dexter-51afbcf6002a7.png",
+            "lang": "en",
+            "likes": "1"
+        },
+        {
+            "id": "29646",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/characterart/dexter-51b0fc45e0dc0.png",
+            "lang": "en",
+            "likes": "1"
+        }
+    ],
+    "clearlogo": [
+        {
+            "id": "20958",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/clearlogo/dexter-5057573260826.png",
+            "lang": "en",
+            "likes": "6"
+        },
+        {
+            "id": "2114",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/clearlogo/Dexter-79349-2.png",
+            "lang": "en",
+            "likes": "4"
+        },
+        {
+            "id": "14577",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/clearlogo/dexter-4ecdf0c030189.png",
+            "lang": "en",
+            "likes": "3"
+        },
+        {
+            "id": "16685",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/clearlogo/dexter-4f6879db58edf.png",
+            "lang": "ru",
+            "likes": "1"
+        }
+    ],
+    "tvposter": [
+        {
+            "id": "34331",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/tvposter/dexter-5251f81d6a966.jpg",
+            "lang": "en",
+            "likes": "5"
+        },
+        {
+            "id": "32420",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/tvposter/dexter-521277d441aa9.jpg",
+            "lang": "en",
+            "likes": "3"
+        },
+        {
+            "id": "39863",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/tvposter/dexter-535f654d173f2.jpg",
+            "lang": "en",
+            "likes": "3"
+        },
+        {
+            "id": "44347",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/tvposter/dexter-5402ddeace245.jpg",
+            "lang": "de",
+            "likes": "2"
+        },
+        {
+            "id": "33256",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/tvposter/dexter-522613e9169f5.jpg",
+            "lang": "he",
+            "likes": "2"
+        },
+        {
+            "id": "67896",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/tvposter/dexter-583183afab5dc.jpg",
+            "lang": "00",
+            "likes": "1"
+        },
+        {
+            "id": "67898",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/tvposter/dexter-583183afac80b.jpg",
+            "lang": "00",
+            "likes": "1"
+        },
+        {
+            "id": "67908",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/tvposter/dexter-583183c32c9fe.jpg",
+            "lang": "en",
+            "likes": "1"
+        },
+        {
+            "id": "67914",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/tvposter/dexter-5831957d46802.jpg",
+            "lang": "00",
+            "likes": "1"
+        },
+        {
+            "id": "83079",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/tvposter/dexter-5a9c404413241.jpg",
+            "lang": "en",
+            "likes": "1"
+        },
+        {
+            "id": "78406",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/tvposter/dexter-59b19badbee8a.jpg",
+            "lang": "00",
+            "likes": "0"
+        }
+    ],
+    "showbackground": [
+        {
+            "id": "18467",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/showbackground/dexter-4fc683691dea7.jpg",
+            "lang": "",
+            "likes": "5",
+            "season": "1"
+        },
+        {
+            "id": "18468",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/showbackground/dexter-4fc683a5ab451.jpg",
+            "lang": "",
+            "likes": "3",
+            "season": "6"
+        },
+        {
+            "id": "67878",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/showbackground/dexter-583183539d11d.jpg",
+            "lang": "",
+            "likes": "3",
+            "season": "all"
+        },
+        {
+            "id": "67884",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/showbackground/dexter-583183539fb9b.jpg",
+            "lang": "",
+            "likes": "3",
+            "season": "all"
+        },
+        {
+            "id": "18950",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/showbackground/dexter-4fdf608e2df53.jpg",
+            "lang": "",
+            "likes": "2",
+            "season": "3"
+        },
+        {
+            "id": "21524",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/showbackground/dexter-506bdd9c35771.jpg",
+            "lang": "",
+            "likes": "2",
+            "season": "all"
+        },
+        {
+            "id": "21526",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/showbackground/dexter-506bddc9f04cb.jpg",
+            "lang": "",
+            "likes": "2",
+            "season": "all"
+        },
+        {
+            "id": "21527",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/showbackground/dexter-506bdddc3f476.jpg",
+            "lang": "",
+            "likes": "2",
+            "season": "all"
+        },
+        {
+            "id": "67877",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/showbackground/dexter-583183539c2d2.jpg",
+            "lang": "",
+            "likes": "2",
+            "season": "all"
+        },
+        {
+            "id": "67881",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/showbackground/dexter-583183539e86a.jpg",
+            "lang": "",
+            "likes": "2",
+            "season": "all"
+        },
+        {
+            "id": "67882",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/showbackground/dexter-583183539ef39.jpg",
+            "lang": "",
+            "likes": "2",
+            "season": "all"
+        },
+        {
+            "id": "67883",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/showbackground/dexter-583183539f56e.jpg",
+            "lang": "",
+            "likes": "2",
+            "season": "all"
+        },
+        {
+            "id": "83084",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/showbackground/dexter-5a9c5a53e8c61.jpg",
+            "lang": "",
+            "likes": "2",
+            "season": "all"
+        },
+        {
+            "id": "83085",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/showbackground/dexter-5a9c5a53f009e.jpg",
+            "lang": "",
+            "likes": "2",
+            "season": "all"
+        },
+        {
+            "id": "83086",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/showbackground/dexter-5a9c5a5403ddd.jpg",
+            "lang": "",
+            "likes": "2",
+            "season": "all"
+        },
+        {
+            "id": "32193",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/showbackground/dexter-520e19dd4de8c.jpg",
+            "lang": "",
+            "likes": "2",
+            "season": "all"
+        },
+        {
+            "id": "24046",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/showbackground/dexter-50de1f84e736f.jpg",
+            "lang": "",
+            "likes": "2",
+            "season": "all"
+        },
+        {
+            "id": "24055",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/showbackground/dexter-50def777e8dbc.jpg",
+            "lang": "",
+            "likes": "2",
+            "season": "all"
+        },
+        {
+            "id": "24058",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/showbackground/dexter-50def777ea9c8.jpg",
+            "lang": "",
+            "likes": "2",
+            "season": "all"
+        },
+        {
+            "id": "34303",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/showbackground/dexter-5250cd641c716.jpg",
+            "lang": "",
+            "likes": "2",
+            "season": "all"
+        },
+        {
+            "id": "18952",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/showbackground/dexter-4fdf6386ce1c1.jpg",
+            "lang": "",
+            "likes": "1",
+            "season": "all"
+        },
+        {
+            "id": "21525",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/showbackground/dexter-506bddb3bd3f4.jpg",
+            "lang": "",
+            "likes": "1",
+            "season": "all"
+        },
+        {
+            "id": "18466",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/showbackground/dexter-4fc6830dc2ccc.jpg",
+            "lang": "",
+            "likes": "1",
+            "season": "4"
+        },
+        {
+            "id": "67880",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/showbackground/dexter-583183539e166.jpg",
+            "lang": "",
+            "likes": "1",
+            "season": "all"
+        },
+        {
+            "id": "24049",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/showbackground/dexter-50de21ac3ae25.jpg",
+            "lang": "",
+            "likes": "1",
+            "season": "all"
+        },
+        {
+            "id": "24054",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/showbackground/dexter-50def777e84d0.jpg",
+            "lang": "",
+            "likes": "1",
+            "season": "all"
+        },
+        {
+            "id": "36343",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/showbackground/dexter-52d406b724ab8.jpg",
+            "lang": "",
+            "likes": "1",
+            "season": "all"
+        },
+        {
+            "id": "24056",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/showbackground/dexter-50def777e9762.jpg",
+            "lang": "",
+            "likes": "1",
+            "season": "all"
+        },
+        {
+            "id": "18947",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/showbackground/dexter-4fdf5e107be0d.jpg",
+            "lang": "",
+            "likes": "0",
+            "season": "5"
+        },
+        {
+            "id": "18949",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/showbackground/dexter-4fdf601385517.jpg",
+            "lang": "",
+            "likes": "0",
+            "season": "all"
+        },
+        {
+            "id": "21529",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/showbackground/dexter-506bde113406e.jpg",
+            "lang": "",
+            "likes": "0",
+            "season": "all"
+        },
+        {
+            "id": "18515",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/showbackground/dexter-4fc8eab16803c.jpg",
+            "lang": "",
+            "likes": "0",
+            "season": "all"
+        },
+        {
+            "id": "24986",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/showbackground/dexter-5101fa187c857.jpg",
+            "lang": "",
+            "likes": "0",
+            "season": "all"
+        },
+        {
+            "id": "33202",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/showbackground/dexter-5224d4d8b7b2a.jpg",
+            "lang": "",
+            "likes": "0",
+            "season": "all"
+        },
+        {
+            "id": "24048",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/showbackground/dexter-50de1f84e7d57.jpg",
+            "lang": "",
+            "likes": "0",
+            "season": "all"
+        }
+    ],
+    "clearart": [
+        {
+            "id": "4980",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/clearart/D_79349 (3).png",
+            "lang": "en",
+            "likes": "5"
+        },
+        {
+            "id": "14579",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/clearart/dexter-4ecdf0db2adf1.png",
+            "lang": "en",
+            "likes": "4"
+        },
+        {
+            "id": "16682",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/clearart/dexter-4f68753540f2d.png",
+            "lang": "ru",
+            "likes": "1"
+        },
+        {
+            "id": "17196",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/clearart/dexter-4f8af83f3bde7.png",
+            "lang": "en",
+            "likes": "0"
+        },
+        {
+            "id": "4982",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/clearart/D_79349.png",
+            "lang": "en",
+            "likes": "0"
+        },
+        {
+            "id": "4983",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/clearart/D_79349 (1).png",
+            "lang": "en",
+            "likes": "0"
+        },
+        {
+            "id": "4984",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/clearart/D_79349 (0).png",
+            "lang": "en",
+            "likes": "0"
+        },
+        {
+            "id": "14578",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/clearart/dexter-4ecdf0cf3fb38.png",
+            "lang": "en",
+            "likes": "0"
+        }
+    ],
+    "tvthumb": [
+        {
+            "id": "31722",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/tvthumb/dexter-51f27112a2a89.jpg",
+            "lang": "en",
+            "likes": "4"
+        },
+        {
+            "id": "67892",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/tvthumb/dexter-58318380c7599.jpg",
+            "lang": "en",
+            "likes": "3"
+        },
+        {
+            "id": "5012",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/tvthumb/D_79349 (10).jpg",
+            "lang": "en",
+            "likes": "3"
+        },
+        {
+            "id": "29341",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/tvthumb/dexter-51a338d376b4a.jpg",
+            "lang": "de",
+            "likes": "2"
+        },
+        {
+            "id": "5023",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/tvthumb/D_79349 (0).jpg",
+            "lang": "en",
+            "likes": "2"
+        },
+        {
+            "id": "14580",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/tvthumb/dexter-4ecdf5027a53c.jpg",
+            "lang": "en",
+            "likes": "2"
+        },
+        {
+            "id": "67889",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/tvthumb/dexter-58318380c5b8d.jpg",
+            "lang": "en",
+            "likes": "1"
+        },
+        {
+            "id": "67890",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/tvthumb/dexter-58318380c68a8.jpg",
+            "lang": "en",
+            "likes": "1"
+        },
+        {
+            "id": "67893",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/tvthumb/dexter-58318380c7be8.jpg",
+            "lang": "en",
+            "likes": "1"
+        },
+        {
+            "id": "5013",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/tvthumb/D_79349 (9).jpg",
+            "lang": "en",
+            "likes": "1"
+        },
+        {
+            "id": "5016",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/tvthumb/D_79349 (6).jpg",
+            "lang": "en",
+            "likes": "1"
+        },
+        {
+            "id": "5020",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/tvthumb/D_79349 (2).jpg",
+            "lang": "en",
+            "likes": "1"
+        },
+        {
+            "id": "14277",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/tvthumb/dexter-4ead4375923fd.jpg",
+            "lang": "en",
+            "likes": "1"
+        },
+        {
+            "id": "33261",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/tvthumb/dexter-522648127939e.jpg",
+            "lang": "he",
+            "likes": "1"
+        },
+        {
+            "id": "5010",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/tvthumb/D_79349 (12).jpg",
+            "lang": "en",
+            "likes": "0"
+        },
+        {
+            "id": "5011",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/tvthumb/D_79349 (11).jpg",
+            "lang": "en",
+            "likes": "0"
+        },
+        {
+            "id": "5014",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/tvthumb/D_79349 (8).jpg",
+            "lang": "en",
+            "likes": "0"
+        },
+        {
+            "id": "5015",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/tvthumb/D_79349 (7).jpg",
+            "lang": "en",
+            "likes": "0"
+        },
+        {
+            "id": "5017",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/tvthumb/D_79349 (5).jpg",
+            "lang": "en",
+            "likes": "0"
+        },
+        {
+            "id": "5018",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/tvthumb/D_79349 (4).jpg",
+            "lang": "en",
+            "likes": "0"
+        },
+        {
+            "id": "5019",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/tvthumb/D_79349 (3).jpg",
+            "lang": "en",
+            "likes": "0"
+        },
+        {
+            "id": "5021",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/tvthumb/D_79349.jpg",
+            "lang": "en",
+            "likes": "0"
+        },
+        {
+            "id": "5022",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/tvthumb/D_79349 (1).jpg",
+            "lang": "en",
+            "likes": "0"
+        }
+    ],
+    "seasonthumb": [
+        {
+            "id": "18986",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonthumb/dexter-4fe21b7708ebe.jpg",
+            "lang": "en",
+            "likes": "3",
+            "season": "6"
+        },
+        {
+            "id": "35585",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonthumb/dexter-52aa23371bfd1.jpg",
+            "lang": "en",
+            "likes": "1",
+            "season": "8"
+        },
+        {
+            "id": "35586",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonthumb/dexter-52aa2340b016e.jpg",
+            "lang": "en",
+            "likes": "1",
+            "season": "8"
+        },
+        {
+            "id": "18980",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonthumb/dexter-4fe21a6955116.jpg",
+            "lang": "en",
+            "likes": "1",
+            "season": "1"
+        },
+        {
+            "id": "18982",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonthumb/dexter-4fe21b0767edb.jpg",
+            "lang": "en",
+            "likes": "1",
+            "season": "2"
+        },
+        {
+            "id": "18983",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonthumb/dexter-4fe21b292d661.jpg",
+            "lang": "en",
+            "likes": "1",
+            "season": "3"
+        },
+        {
+            "id": "18984",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonthumb/dexter-4fe21b42d983d.jpg",
+            "lang": "en",
+            "likes": "1",
+            "season": "4"
+        },
+        {
+            "id": "18985",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonthumb/dexter-4fe21b5847d7b.jpg",
+            "lang": "en",
+            "likes": "1",
+            "season": "5"
+        },
+        {
+            "id": "21883",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonthumb/dexter-5071800d37e80.jpg",
+            "lang": "en",
+            "likes": "1",
+            "season": "7"
+        },
+        {
+            "id": "5002",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonthumb/Dexter (6).jpg",
+            "lang": "en",
+            "likes": "1",
+            "season": "3"
+        },
+        {
+            "id": "17802",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonthumb/dexter-4fa981a7251d7.jpg",
+            "lang": "en",
+            "likes": "1",
+            "season": "5"
+        },
+        {
+            "id": "5003",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonthumb/Dexter (5).jpg",
+            "lang": "en",
+            "likes": "1",
+            "season": "1"
+        },
+        {
+            "id": "17823",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonthumb/dexter-4faab0bccbfb6.jpg",
+            "lang": "en",
+            "likes": "1",
+            "season": "6"
+        },
+        {
+            "id": "33262",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonthumb/dexter-522648bfbfe72.jpg",
+            "lang": "he",
+            "likes": "1",
+            "season": "1"
+        },
+        {
+            "id": "33263",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonthumb/dexter-522648ff989df.jpg",
+            "lang": "he",
+            "likes": "1",
+            "season": "2"
+        },
+        {
+            "id": "33264",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonthumb/dexter-5226492b7f2ff.jpg",
+            "lang": "he",
+            "likes": "1",
+            "season": "3"
+        },
+        {
+            "id": "33265",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonthumb/dexter-522649758054c.jpg",
+            "lang": "he",
+            "likes": "1",
+            "season": "4"
+        },
+        {
+            "id": "33266",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonthumb/dexter-522649ccebbfe.jpg",
+            "lang": "he",
+            "likes": "1",
+            "season": "5"
+        },
+        {
+            "id": "33267",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonthumb/dexter-52264a005f5de.jpg",
+            "lang": "he",
+            "likes": "1",
+            "season": "6"
+        },
+        {
+            "id": "33268",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonthumb/dexter-52264a5763db2.jpg",
+            "lang": "he",
+            "likes": "1",
+            "season": "7"
+        },
+        {
+            "id": "33269",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonthumb/dexter-52264acd22558.jpg",
+            "lang": "he",
+            "likes": "1",
+            "season": "8"
+        },
+        {
+            "id": "31022",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonthumb/dexter-51dc720661cb7.jpg",
+            "lang": "en",
+            "likes": "0",
+            "season": "8"
+        },
+        {
+            "id": "31023",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonthumb/dexter-51dc72a19a0bb.jpg",
+            "lang": "en",
+            "likes": "0",
+            "season": "8"
+        },
+        {
+            "id": "18514",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonthumb/dexter-4fc8e9fa79bf8.jpg",
+            "lang": "en",
+            "likes": "0",
+            "season": "7"
+        },
+        {
+            "id": "4989",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonthumb/Dexter (9).jpg",
+            "lang": "en",
+            "likes": "0",
+            "season": "all"
+        },
+        {
+            "id": "4990",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonthumb/Dexter (19).jpg",
+            "lang": "en",
+            "likes": "0",
+            "season": "4"
+        },
+        {
+            "id": "4991",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonthumb/Dexter (18).jpg",
+            "lang": "en",
+            "likes": "0",
+            "season": "4"
+        },
+        {
+            "id": "4992",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonthumb/Dexter (17).jpg",
+            "lang": "en",
+            "likes": "0",
+            "season": "3"
+        },
+        {
+            "id": "4993",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonthumb/Dexter (16).jpg",
+            "lang": "en",
+            "likes": "0",
+            "season": "2"
+        },
+        {
+            "id": "4994",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonthumb/Dexter (15).jpg",
+            "lang": "en",
+            "likes": "0",
+            "season": "1"
+        },
+        {
+            "id": "4995",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonthumb/Dexter (14).jpg",
+            "lang": "en",
+            "likes": "0",
+            "season": "all"
+        },
+        {
+            "id": "4996",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonthumb/Dexter (13).jpg",
+            "lang": "en",
+            "likes": "0",
+            "season": "4"
+        },
+        {
+            "id": "4997",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonthumb/Dexter (12).jpg",
+            "lang": "en",
+            "likes": "0",
+            "season": "3"
+        },
+        {
+            "id": "4998",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonthumb/Dexter (11).jpg",
+            "lang": "en",
+            "likes": "0",
+            "season": "2"
+        },
+        {
+            "id": "4999",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonthumb/Dexter (10).jpg",
+            "lang": "en",
+            "likes": "0",
+            "season": "1"
+        },
+        {
+            "id": "5000",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonthumb/Dexter (8).jpg",
+            "lang": "en",
+            "likes": "0",
+            "season": "2"
+        },
+        {
+            "id": "5001",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonthumb/Dexter (7).jpg",
+            "lang": "en",
+            "likes": "0",
+            "season": "4"
+        },
+        {
+            "id": "17803",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonthumb/dexter-4fa981a7258fb.jpg",
+            "lang": "en",
+            "likes": "0",
+            "season": "5"
+        },
+        {
+            "id": "5004",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonthumb/Dexter.jpg",
+            "lang": "en",
+            "likes": "0",
+            "season": "all"
+        },
+        {
+            "id": "17804",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonthumb/dexter-4fa981a725c14.jpg",
+            "lang": "en",
+            "likes": "0",
+            "season": "5"
+        },
+        {
+            "id": "5005",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonthumb/Dexter (4).jpg",
+            "lang": "en",
+            "likes": "0",
+            "season": "5"
+        },
+        {
+            "id": "17805",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonthumb/dexter-4fa981c6607e4.jpg",
+            "lang": "en",
+            "likes": "0",
+            "season": "0"
+        },
+        {
+            "id": "5006",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonthumb/Dexter (3).jpg",
+            "lang": "en",
+            "likes": "0",
+            "season": "4"
+        },
+        {
+            "id": "5007",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonthumb/Dexter (2).jpg",
+            "lang": "en",
+            "likes": "0",
+            "season": "3"
+        },
+        {
+            "id": "17807",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonthumb/dexter-4fa98ac2b811d.jpg",
+            "lang": "en",
+            "likes": "0",
+            "season": "6"
+        },
+        {
+            "id": "5008",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonthumb/Dexter (1).jpg",
+            "lang": "en",
+            "likes": "0",
+            "season": "2"
+        },
+        {
+            "id": "17808",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonthumb/dexter-4fa98ac2b87ab.jpg",
+            "lang": "en",
+            "likes": "0",
+            "season": "6"
+        },
+        {
+            "id": "5009",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonthumb/Dexter (0).jpg",
+            "lang": "en",
+            "likes": "0",
+            "season": "1"
+        },
+        {
+            "id": "17810",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonthumb/dexter-4fa994697afa3.jpg",
+            "lang": "en",
+            "likes": "0",
+            "season": "6"
+        }
+    ],
+    "tvbanner": [
+        {
+            "id": "30063",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/tvbanner/dexter-51bfc89667267.jpg",
+            "lang": "en",
+            "likes": "3"
+        },
+        {
+            "id": "55124",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/tvbanner/dexter-55a6a0c9741cf.jpg",
+            "lang": "en",
+            "likes": "2"
+        },
+        {
+            "id": "30062",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/tvbanner/dexter-51bfc857c84fd.jpg",
+            "lang": "en",
+            "likes": "1"
+        },
+        {
+            "id": "54982",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/tvbanner/dexter-55a26f57b2875.jpg",
+            "lang": "en",
+            "likes": "1"
+        },
+        {
+            "id": "33270",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/tvbanner/dexter-52264bbad5b81.jpg",
+            "lang": "he",
+            "likes": "1"
+        },
+        {
+            "id": "35192",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/tvbanner/dexter-527d5d075dc35.jpg",
+            "lang": "en",
+            "likes": "0"
+        },
+        {
+            "id": "35193",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/tvbanner/dexter-527d5d18dee23.jpg",
+            "lang": "en",
+            "likes": "0"
+        },
+        {
+            "id": "34785",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/tvbanner/dexter-52670388cd091.jpg",
+            "lang": "en",
+            "likes": "0"
+        }
+    ],
+    "seasonbanner": [
+        {
+            "id": "38922",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonbanner/dexter-534cda15476b0.jpg",
+            "lang": "en",
+            "likes": "0",
+            "season": "1"
+        },
+        {
+            "id": "38923",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonbanner/dexter-534cda21d67f4.jpg",
+            "lang": "en",
+            "likes": "0",
+            "season": "2"
+        },
+        {
+            "id": "38924",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonbanner/dexter-534cda2c573e3.jpg",
+            "lang": "en",
+            "likes": "0",
+            "season": "3"
+        },
+        {
+            "id": "38925",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonbanner/dexter-534cda37326a0.jpg",
+            "lang": "en",
+            "likes": "0",
+            "season": "4"
+        },
+        {
+            "id": "38926",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonbanner/dexter-534cda40849d6.jpg",
+            "lang": "en",
+            "likes": "0",
+            "season": "5"
+        },
+        {
+            "id": "38927",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonbanner/dexter-534cda4d0c8bb.jpg",
+            "lang": "en",
+            "likes": "0",
+            "season": "6"
+        },
+        {
+            "id": "38928",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonbanner/dexter-534cda594e7ff.jpg",
+            "lang": "en",
+            "likes": "0",
+            "season": "7"
+        },
+        {
+            "id": "38929",
+            "url": "https://assets.fanart.tv/fanart/tv/79349/seasonbanner/dexter-534cda670afbe.jpg",
+            "lang": "en",
+            "likes": "0",
+            "season": "8"
+        }
+    ]
 }

--- a/fanart/tests/test_core.py
+++ b/fanart/tests/test_core.py
@@ -10,14 +10,16 @@ class RequestTestCase(TestCase):
 
     @httprettified
     def test_response_error(self):
-        request = Request('apikey', 'objid', 'series')
+        request = Request('apikey', 'objid', 'tv')
         HTTPretty.register_uri(
             HTTPretty.GET,
-            'http://api.fanart.tv/webservice/series/apikey/objid/JSON/all/1/2',
+            'http://webservice.fanart.tv/v3/tv/objid?api_key=apikey',
             body='Please specify a valid API key',
         )
         try:
             request.response()
         except ResponseFanartError as e:
-            self.assertEqual(repr(e), "ResponseFanartError('No JSON object could be decoded',)")
-            self.assertEqual(str(e), 'No JSON object could be decoded')
+            self.assertEqual(repr(e), "ResponseFanartError('Expecting value: "
+                                      "line 1 column 1 (char 0)',)")
+            self.assertEqual(str(e), "Expecting value: "
+                                     "line 1 column 1 (char 0)")

--- a/fanart/tests/test_items.py
+++ b/fanart/tests/test_items.py
@@ -14,7 +14,7 @@ class LeafItemTestCase(TestCase):
 
     @httprettified
     def test_content(self):
-        with open(os.path.join(LOCALDIR, 'response/50x50.png')) as fp:
+        with open(os.path.join(LOCALDIR, 'response/50x50.png'), 'rb') as fp:
             body = fp.read()
         HTTPretty.register_uri(
             HTTPretty.GET,

--- a/fanart/tests/test_movie.py
+++ b/fanart/tests/test_movie.py
@@ -13,7 +13,8 @@ class TvItemTestCase(unittest.TestCase):
             body = fp.read()
         HTTPretty.register_uri(
             HTTPretty.GET,
-            'http://api.fanart.tv/webservice/movie/e3c7f0d0beeaf45b3a0dd3b9dd8a3338/70160/JSON/all/1/2',
+            'http://webservice.fanart.tv/v3/movies/70160?api_key={}'.format(
+                os.environ['FANART_APIKEY']),
             body=body
         )
         hunger_games = Movie.get(id=70160)

--- a/fanart/tests/test_music.py
+++ b/fanart/tests/test_music.py
@@ -9,14 +9,16 @@ os.environ['FANART_APIKEY'] = 'e3c7f0d0beeaf45b3a0dd3b9dd8a3338'
 class ArtistItemTestCase(unittest.TestCase):
     @httprettified
     def test_get(self):
+        artist_id = '24e1b53c-3085-4581-8472-0b0088d2508c'
         with open(os.path.join(LOCALDIR, 'response/music_a7f.json')) as fp:
             body = fp.read()
         HTTPretty.register_uri(
             HTTPretty.GET,
-            'http://api.fanart.tv/webservice/artist/e3c7f0d0beeaf45b3a0dd3b9dd8a3338/24e1b53c-3085-4581-8472-0b0088d2508c/JSON/all/1/2',
+            'http://webservice.fanart.tv/v3/music/{}?api_key={}'.format(
+                artist_id, os.environ['FANART_APIKEY']),
             body=body
         )
-        a7f = Artist.get(id='24e1b53c-3085-4581-8472-0b0088d2508c')
-        self.assertEqual(a7f.mbid, '24e1b53c-3085-4581-8472-0b0088d2508c')
+        a7f = Artist.get(id=artist_id)
+        self.assertEqual(a7f.mbid, artist_id)
         self.assertEqual(a7f, eval(repr(a7f)))
-        self.assertEqual(len(a7f.thumbs), 2)
+        self.assertEqual(len(a7f.thumbs), 4)

--- a/fanart/tests/test_tv.py
+++ b/fanart/tests/test_tv.py
@@ -15,10 +15,16 @@ class TvItemTestCase(unittest.TestCase):
             body = fp.read()
         HTTPretty.register_uri(
             HTTPretty.GET,
-            'http://api.fanart.tv/webservice/series/e3c7f0d0beeaf45b3a0dd3b9dd8a3338/239761/JSON/all/1/2',
+            'http://webservice.fanart.tv/v3/tv/239761?api_key={}'.format(
+                os.environ['FANART_APIKEY']),
             body=body
         )
         wilfred = TvShow.get(id=239761)
+
+        # If we update `response/tv_239761.json`, then we also must update
+        # `json/wilfred.json`, and to do so, we can use the following command:
+        # print(wilfred.json(indent=4))
+
         self.assertEqual(wilfred.tvdbid, '239761')
         with open(os.path.join(LOCALDIR, 'json/wilfred.json')) as fp:
             self.assertEqual(json.loads(wilfred.json()), json.load(fp))
@@ -29,7 +35,8 @@ class TvItemTestCase(unittest.TestCase):
             body = fp.read()
         HTTPretty.register_uri(
             HTTPretty.GET,
-            'http://api.fanart.tv/webservice/series/e3c7f0d0beeaf45b3a0dd3b9dd8a3338/79349/JSON/all/1/2',
+            'http://webservice.fanart.tv/v3/tv/79349?api_key={}'.format(
+                os.environ['FANART_APIKEY']),
             body=body
         )
         dexter = TvShow.get(id=79349)
@@ -40,7 +47,8 @@ class TvItemTestCase(unittest.TestCase):
     def test_get_null(self):
         HTTPretty.register_uri(
             HTTPretty.GET,
-            'http://api.fanart.tv/webservice/series/e3c7f0d0beeaf45b3a0dd3b9dd8a3338/79349/JSON/all/1/2',
+            'http://webservice.fanart.tv/v3/tv/79349?api_key={}'.format(
+                os.environ['FANART_APIKEY']),
             body='null'
         )
         self.assertRaises(ResponseFanartError, TvShow.get, id=79349)

--- a/fanart/tv.py
+++ b/fanart/tv.py
@@ -49,6 +49,14 @@ class SeasonItem(SeasonedTvItem):
     KEY = fanart.TYPE.TV.SEASONTHUMB
 
 
+class SeasonPosterItem(SeasonedTvItem):
+    KEY = fanart.TYPE.TV.SEASONPOSTER
+
+
+class SeasonBannerItem(SeasonedTvItem):
+    KEY = fanart.TYPE.TV.SEASONBANNER
+
+
 class ThumbItem(TvItem):
     KEY = fanart.TYPE.TV.THUMB
 
@@ -73,8 +81,10 @@ class TvShow(ResourceItem):
     WS = fanart.WS.TV
 
     @Immutable.mutablemethod
-    def __init__(self, name, tvdbid, backgrounds, characters, arts, logos, seasons, thumbs, hdlogos, hdarts, posters,
-                 banners):
+    def __init__(
+            self, name, tvdbid, backgrounds, characters, arts, logos,
+            seasons, thumbs, hdlogos, hdarts, posters, banners,
+            season_posters, season_banners):
         self.name = name
         self.tvdbid = tvdbid
         self.backgrounds = backgrounds
@@ -87,6 +97,8 @@ class TvShow(ResourceItem):
         self.hdarts = hdarts
         self.posters = posters
         self.banners = banners
+        self.season_posters = posters
+        self.season_banners = banners
 
     @classmethod
     def from_dict(cls, resource):
@@ -105,4 +117,6 @@ class TvShow(ResourceItem):
             hdarts=HdArtItem.extract(resource),
             posters=PosterItem.extract(resource),
             banners=BannerItem.extract(resource),
+            season_posters=SeasonPosterItem.extract(resource),
+            season_banners=SeasonBannerItem.extract(resource),
         )

--- a/fanart/tv.py
+++ b/fanart/tv.py
@@ -102,10 +102,10 @@ class TvShow(ResourceItem):
 
     @classmethod
     def from_dict(cls, resource):
-        assert len(resource) == 1, 'Bad Format Map'
-        name, resource = list(resource.items())[0]
+        minimal_keys = {'name', 'thetvdb_id'}
+        assert all(k in resource for k in minimal_keys), 'Bad Format Map'
         return cls(
-            name=name,
+            name=resource['name'],
             tvdbid=resource['thetvdb_id'],
             backgrounds=BackgroundItem.extract(resource),
             characters=CharacterItem.extract(resource),

--- a/fanart/tv.py
+++ b/fanart/tv.py
@@ -91,7 +91,7 @@ class TvShow(ResourceItem):
     @classmethod
     def from_dict(cls, resource):
         assert len(resource) == 1, 'Bad Format Map'
-        name, resource = resource.items()[0]
+        name, resource = list(resource.items())[0]
         return cls(
             name=name,
             tvdbid=resource['thetvdb_id'],

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-requests==1.2.3
+requests

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ wd = os.path.dirname(os.path.abspath(__file__))
 os.chdir(wd)
 sys.path.insert(1, wd)
 
-name = 'python-fanart'
+name = 'python3-fanart'
 pkg = __import__('fanart')
 
 author, email = pkg.__author__.rsplit(' ', 1)
@@ -29,7 +29,7 @@ setup(
     version=version,
     author=author,
     author_email=email,
-    url='http://github.com/z4r/python-fanart',
+    url='http://github.com/opacam/python3-fanart',
     maintainer=author,
     maintainer_email=email,
     description=description,

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,9 @@ pkg = __import__('fanart')
 author, email = pkg.__author__.rsplit(' ', 1)
 email = email.strip('<>')
 
+maintainer, maintainer_email = pkg.__maintainer__.rsplit(' ', 1)
+maintainer_email = maintainer_email.strip('<>')
+
 version = pkg.__version__
 classifiers = pkg.__classifiers__
 
@@ -30,8 +33,8 @@ setup(
     author=author,
     author_email=email,
     url='http://github.com/opacam/python3-fanart',
-    maintainer=author,
-    maintainer_email=email,
+    maintainer=maintainer,
+    maintainer_email=maintainer_email,
     description=description,
     long_description=long_description,
     classifiers=classifiers,

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,5 +1,5 @@
 pytest
 pytest-pep8
-pytest-cov
+pytest-cov==2.5.0
 httpretty
 python-coveralls


### PR DESCRIPTION
This pull request migrates the project to the new fanart.tv api (V3) and make it work with Python3. The python2 support has been removed from the project because the end of support for python2 is almost here (2020)...plus maintaining the project for python2 and python3 will add a complexity that I feel unnecesary now a days.

This pull request is created in this fork because it seems to me, that the original project is unmaintained, so I renamed it from `python-fanart` to `python3-fanart` (to reflect the fact that it is for python3).

**Things done here:**
  - [x] make it work with fanart api v3
  - [x] make it work with Python 3.4+
  - [x] drop python 2 support
  - [x] fix all the tests
  - [x] update the test files to latest fanart.tv info
  - [x] add `Season's Posters` and `Season's Banners`
  - [x] make it work all the tests with  api v3 and python 3
  - [x] shorten some lines to be PEP8 friendly
  - [x] fixed all the tests has been
  - [x] add myself as a maintainer of the project
  - [x] make CI travis tests work again
  - [x] add more python versions to test, the ones which we support (3.4, 3.5, 3.6, 3.7)
  - [x] removes the python2 tests